### PR TITLE
Bug fixes

### DIFF
--- a/src/DotNet.GitHub/DefaultResilientGitHubClientFactory.cs
+++ b/src/DotNet.GitHub/DefaultResilientGitHubClientFactory.cs
@@ -1,0 +1,19 @@
+﻿using Octokit;
+using Octokit.Extensions;
+
+namespace DotNet.GitHub
+{
+    public class DefaultResilientGitHubClientFactory : IResilientGitHubClientFactory
+    {
+        readonly ResilientGitHubClientFactory _clientFactory;
+
+        public DefaultResilientGitHubClientFactory(
+            ResilientGitHubClientFactory clientFactory) =>
+            _clientFactory = clientFactory;
+
+        public IGitHubClient Create(string token) =>
+            _clientFactory.Create(
+                productHeaderValue: GitHubProduct.Header,
+                credentials: new(token));
+    }
+}

--- a/src/DotNet.GitHub/GitHubGraphQLClient.cs
+++ b/src/DotNet.GitHub/GitHubGraphQLClient.cs
@@ -49,7 +49,7 @@ namespace DotNet.GitHub
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new("Token", token);
                 _httpClient.DefaultRequestHeaders.UserAgent.Add(
-                    new(Product.Header.Name, Product.Header.Version));
+                    new(GitHubProduct.Header.Name, GitHubProduct.Header.Version));
 
                 GraphQLRequest graphQLRequest = new()
                 {

--- a/src/DotNet.GitHub/GitHubIssueService.cs
+++ b/src/DotNet.GitHub/GitHubIssueService.cs
@@ -7,12 +7,12 @@ namespace DotNet.GitHub
 {
     public class GitHubIssueService : IGitHubIssueService
     {
-        readonly ResilientGitHubClientFactory _clientFactory;
+        readonly IResilientGitHubClientFactory _clientFactory;
         readonly IGitHubLabelService _gitHubLabelService;
         readonly ILogger<GitHubIssueService> _logger;
 
         public GitHubIssueService(
-            ResilientGitHubClientFactory clientFactory,
+            IResilientGitHubClientFactory clientFactory,
             IGitHubLabelService gitHubLabelService,
             ILogger<GitHubIssueService> logger) =>
             (_clientFactory, _gitHubLabelService, _logger) = (clientFactory, gitHubLabelService, logger);
@@ -35,10 +35,7 @@ namespace DotNet.GitHub
 
         IIssuesClient GetIssuesClient(string token)
         {
-            var client = _clientFactory.Create(
-                productHeaderValue: Product.Header,
-                credentials: new(token));
-
+            var client = _clientFactory.Create(token);
             return client.Issue;
         }
     }

--- a/src/DotNet.GitHub/GitHubProduct.cs
+++ b/src/DotNet.GitHub/GitHubProduct.cs
@@ -2,11 +2,11 @@
 
 namespace DotNet.GitHub
 {
-    static class Product
+    public static class GitHubProduct
     {
         static readonly string _name = "DotNetVersionSweeper";
         static readonly string _version = "1.0";
 
-        internal static ProductHeaderValue Header { get; } = new(_name, _version);
+        public static ProductHeaderValue Header { get; } = new(_name, _version);
     }
 }

--- a/src/DotNet.GitHub/IResilientGitHubClientFactory.cs
+++ b/src/DotNet.GitHub/IResilientGitHubClientFactory.cs
@@ -1,0 +1,9 @@
+﻿using Octokit;
+
+namespace DotNet.GitHub
+{
+    public interface IResilientGitHubClientFactory
+    {
+        IGitHubClient Create(string token);
+    }
+}

--- a/src/DotNet.GitHub/ServiceCollectionExtensions.cs
+++ b/src/DotNet.GitHub/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ namespace DotNet.GitHub
 
             return services
                 .AddSingleton<ResilientGitHubClientFactory>()
+                .AddSingleton<IResilientGitHubClientFactory, DefaultResilientGitHubClientFactory>()
                 .AddSingleton<GitHubGraphQLClient>()
                 .AddSingleton<RateLimitAwareQueue>()
                 .AddSingleton<IGitHubIssueService, GitHubIssueService>()

--- a/src/DotNet.Releases/Reporting/UnsupportedProjectReporter.cs
+++ b/src/DotNet.Releases/Reporting/UnsupportedProjectReporter.cs
@@ -24,14 +24,13 @@ namespace DotNet.Releases
             HashSet<TargetFrameworkMonikerSupport> resultingSupports = new();
 
             var products = await _coreReleaseIndexService.GetReleasesAsync();
-            foreach (var (product, release) 
-                in products.SelectMany(p => p.Value, (kvp, releases) => (kvp.Key, releases)))
+            foreach (var product in products.Keys)
             {
                 var tfmSupports =
                     project.Tfms.Select(
                         tfm => TryEvaluateReleaseSupport(
                             tfm, product.ProductVersion,
-                            release, out var tfmSupport)
+                            product, out var tfmSupport)
                                 ? tfmSupport : null)
                         .Where(tfmSupport => tfmSupport is not null);
 
@@ -98,10 +97,9 @@ namespace DotNet.Releases
 
         static bool TryEvaluateReleaseSupport(
             string tfm, string version,
-            ProductRelease productRelease,
+            Product product,
             out TargetFrameworkMonikerSupport? tfmSupport)
         {
-            var product = productRelease.Product;
             var release = ReleaseFactory.Create(
                 product,
                 pr => $"{pr.ProductName} {pr.ProductVersion}",

--- a/src/DotNet.VersionSweeper/Program.cs
+++ b/src/DotNet.VersionSweeper/Program.cs
@@ -55,11 +55,12 @@ static async Task StartSweeperAsync(Options options, IServiceProvider services, 
             }
             else
             {
+                var markdownBody = getBody(options);
                 queue.Enqueue(
                     new(options.Owner, options.Name, options.Token),
                     new(title)
                     {
-                        Body = getBody(options)
+                        Body = markdownBody
                     });
             }
         }

--- a/test/DotNet.GitHubTests/DotNet.GitHubTests.csproj
+++ b/test/DotNet.GitHubTests/DotNet.GitHubTests.csproj
@@ -8,9 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.14" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/test/DotNet.GitHubTests/DotNet.GitHubTests.csproj
+++ b/test/DotNet.GitHubTests/DotNet.GitHubTests.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/test/DotNet.GitHubTests/GitHubLabelServiceTests.cs
+++ b/test/DotNet.GitHubTests/GitHubLabelServiceTests.cs
@@ -1,0 +1,69 @@
+﻿using Xunit;
+using DotNet.GitHub;
+using System.Threading.Tasks;
+using Octokit;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using System;
+
+namespace DotNet.GitHubTests
+{
+    public class GitHubLabelServiceTests
+    {
+        readonly ILogger<GitHubLabelService> _logger = new LoggerFactory().CreateLogger<GitHubLabelService>();
+        readonly MemoryCache _cache = new(Options.Create(new MemoryCacheOptions()));
+
+        [Fact]
+        public async Task GetOrCreateLabelAsyncCorrectlyReadsLabel()
+        {
+            var labelsClient = Substitute.For<IIssuesLabelsClient>();
+            labelsClient.GetAllForRepository(null, null).ReturnsForAnyArgs(
+                new[]
+                {
+                    new TestLabel("dotnet-target-version")
+                });
+            var issuesClient = Substitute.For<IIssuesClient>();
+            issuesClient.Labels.ReturnsForAnyArgs(labelsClient);
+            var client = Substitute.For<IGitHubClient>();
+            client.Issue.Returns(issuesClient);
+            var factory = Substitute.For<IResilientGitHubClientFactory>();
+            factory.Create(null).ReturnsForAnyArgs(client);
+
+            var sut = new GitHubLabelService(factory, _logger, _cache);
+            var label = await sut.GetOrCreateLabelAsync("unit", "test", "fake");
+
+            Assert.Equal("dotnet-target-version", label.Name);
+        }
+
+        [Fact]
+        public async Task GetOrCreateLabelAsyncCreatesLabel()
+        {
+            var labelsClient = Substitute.For<IIssuesLabelsClient>();
+            labelsClient.GetAllForRepository(null, null).ReturnsForAnyArgs(
+                Array.Empty<Label>());
+            labelsClient.Create(null, null, null).ReturnsForAnyArgs(
+                new TestLabel("dotnet-target-version"));
+            var issuesClient = Substitute.For<IIssuesClient>();
+            issuesClient.Labels.ReturnsForAnyArgs(labelsClient);
+            var client = Substitute.For<IGitHubClient>();
+            client.Issue.Returns(issuesClient);
+            var factory = Substitute.For<IResilientGitHubClientFactory>();
+            factory.Create(null).ReturnsForAnyArgs(client);
+
+            var sut = new GitHubLabelService(factory, _logger, _cache);
+            var label = await sut.GetOrCreateLabelAsync("unit", "test", "fake");
+
+            await labelsClient.Received().Create(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<NewLabel>());
+
+            Assert.Equal("dotnet-target-version", label.Name);
+        }
+    }
+
+    public class TestLabel : Label
+    {
+        public TestLabel(string name) => Name = name;
+    }
+}


### PR DESCRIPTION
Bugs fixed in this PR:

- With the changes introduced in #17, there was a flaw in the iteration of the products and corresponding releases. We only needed to iterate the product, not each release. This caused multiple releases to be reported for a single TFM - which is invalid. See [issue here](https://github.com/dotnet/versionsweeper/issues/23).

- There was a race condition in the creation of the label. We need to ensure that a label is only created once if it doesn't already exist. See [error here](https://github.com/dotnet/versionsweeper/runs/1963244023?check_suite_focus=true#step:5:142).

Other bits:

- Renamed `Product` to `GitHubProduct` to disambiguate 
- Added unit tests
- Had to abstract out `ResilientGitHubClientFactory` to support unit test subs/mocks
