### PR TITLE
Add unit tests for GitHub action class lib

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,200 @@
-﻿[*.cs]
+﻿# editorconfig.org
 
-# IDE0061: Use block body for local functions
-csharp_style_expression_bodied_local_functions = false
+# top-most EditorConfig file
+root = true
 
-# IDE0040: Add accessibility modifiers
-dotnet_style_require_accessibility_modifiers = never
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[project.json]
+indent_size = 2
+
+# Generated code
+[*{_AssemblyInfo.cs,.notsupported.cs}]
+generated_code = true
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Code quality
+dotnet_style_readonly_field = true:suggestion
+dotnet_code_quality_unused_parameters = non_public:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_constructors = true:silent
+csharp_style_expression_bodied_operators = true:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Analyzers
+dotnet_code_quality.ca1802.api_surface = private, internal
+dotnet_code_quality.ca1822.api_surface = private, internal
+dotnet_code_quality.ca2208.api_surface = public
+
+# License header
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
+
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+[*.{csproj,vbproj,proj,nativeproj,locproj}]
+charset = utf-8
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# YAML config files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd,bat}]
+end_of_line = crlf

--- a/dotnet-versionsweeper.sln
+++ b/dotnet-versionsweeper.sln
@@ -64,6 +64,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNet.IO", "src\DotNet.IO\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNet.IOTests", "test\DotNet.IOTests\DotNet.IOTests.csproj", "{B401F1C9-3212-490D-979A-E35B510FBDE9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNet.GitHubActionsTests", "test\DotNet.GitHubActionsTests\DotNet.GitHubActionsTests.csproj", "{D41F19E7-3FC5-4E41-8F46-9ADA2B7D6EAF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -134,6 +136,10 @@ Global
 		{B401F1C9-3212-490D-979A-E35B510FBDE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B401F1C9-3212-490D-979A-E35B510FBDE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B401F1C9-3212-490D-979A-E35B510FBDE9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D41F19E7-3FC5-4E41-8F46-9ADA2B7D6EAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D41F19E7-3FC5-4E41-8F46-9ADA2B7D6EAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D41F19E7-3FC5-4E41-8F46-9ADA2B7D6EAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D41F19E7-3FC5-4E41-8F46-9ADA2B7D6EAF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -157,6 +163,7 @@ Global
 		{412A1687-B123-4D37-A6C9-DD6197A214D9} = {3241C58C-62C0-40DD-9B85-43A50641A3FA}
 		{BD2148A3-7D83-4AE8-A199-437E8258289F} = {503A8641-B4A5-4D57-9CD2-54C5F894E88D}
 		{B401F1C9-3212-490D-979A-E35B510FBDE9} = {0E68FE58-BFAB-45C8-8EB5-52C74A6ADF7E}
+		{D41F19E7-3FC5-4E41-8F46-9ADA2B7D6EAF} = {0E68FE58-BFAB-45C8-8EB5-52C74A6ADF7E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {70E27639-9B58-4BD1-93FB-05D76A8A32EF}

--- a/src/DotNet.Extensions/DictionaryExtensions.cs
+++ b/src/DotNet.Extensions/DictionaryExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -17,7 +20,7 @@ namespace DotNet.Extensions
         {
             private readonly IDictionary<TKey, TValue> _dictionary;
 
-            public ReadOnlyDictionaryWrapper(IDictionary<TKey, TValue> dictionary) => 
+            public ReadOnlyDictionaryWrapper(IDictionary<TKey, TValue> dictionary) =>
                 _dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
 
             public bool ContainsKey(TKey key) => _dictionary.ContainsKey(key);

--- a/src/DotNet.Extensions/EnumerableExtensions.cs
+++ b/src/DotNet.Extensions/EnumerableExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/DotNet.Extensions/ObjectExtensions.cs
+++ b/src/DotNet.Extensions/ObjectExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/DotNet.Extensions/StringExtensions.cs
+++ b/src/DotNet.Extensions/StringExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.IO;
 
 namespace DotNet.Extensions

--- a/src/DotNet.GitHub/DefaultLabel.cs
+++ b/src/DotNet.GitHub/DefaultLabel.cs
@@ -1,4 +1,7 @@
-﻿using Octokit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Octokit;
 
 namespace DotNet.GitHub
 {

--- a/src/DotNet.GitHub/DefaultResilientGitHubClientFactory.cs
+++ b/src/DotNet.GitHub/DefaultResilientGitHubClientFactory.cs
@@ -1,4 +1,7 @@
-﻿using Octokit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Octokit;
 using Octokit.Extensions;
 
 namespace DotNet.GitHub

--- a/src/DotNet.GitHub/ExistingIssue.cs
+++ b/src/DotNet.GitHub/ExistingIssue.cs
@@ -1,5 +1,8 @@
-﻿using Octokit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
+using Octokit;
 
 namespace DotNet.GitHub
 {

--- a/src/DotNet.GitHub/GitHubApiArgs.cs
+++ b/src/DotNet.GitHub/GitHubApiArgs.cs
@@ -1,4 +1,7 @@
-﻿namespace DotNet.GitHub
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DotNet.GitHub
 {
     public record GitHubApiArgs(string Owner, string RepoName, string Token);
 }

--- a/src/DotNet.GitHub/GitHubGraphQLClient.cs
+++ b/src/DotNet.GitHub/GitHubGraphQLClient.cs
@@ -1,6 +1,6 @@
-﻿using DotNet.Extensions;
-using Microsoft.Extensions.Logging;
-using Octokit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Linq;
 using System.Net.Http;
@@ -8,6 +8,9 @@ using System.Net.Mime;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using DotNet.Extensions;
+using Microsoft.Extensions.Logging;
+using Octokit;
 
 namespace DotNet.GitHub
 {

--- a/src/DotNet.GitHub/GitHubIssueService.cs
+++ b/src/DotNet.GitHub/GitHubIssueService.cs
@@ -1,7 +1,10 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Octokit;
 using Octokit.Extensions;
-using System.Threading.Tasks;
 
 namespace DotNet.GitHub
 {

--- a/src/DotNet.GitHub/GitHubLabelService.cs
+++ b/src/DotNet.GitHub/GitHubLabelService.cs
@@ -1,11 +1,14 @@
-﻿using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Logging;
-using Octokit;
-using Octokit.Extensions;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Octokit;
+using Octokit.Extensions;
 
 namespace DotNet.GitHub
 {

--- a/src/DotNet.GitHub/GitHubProduct.cs
+++ b/src/DotNet.GitHub/GitHubProduct.cs
@@ -1,4 +1,7 @@
-﻿using Octokit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Octokit;
 
 namespace DotNet.GitHub
 {

--- a/src/DotNet.GitHub/GraphQLRequest.cs
+++ b/src/DotNet.GitHub/GraphQLRequest.cs
@@ -1,6 +1,9 @@
-﻿using DotNet.Extensions;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using DotNet.Extensions;
 
 namespace DotNet.GitHub
 {

--- a/src/DotNet.GitHub/IGitHubIssueService.cs
+++ b/src/DotNet.GitHub/IGitHubIssueService.cs
@@ -1,5 +1,8 @@
-﻿using Octokit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Threading.Tasks;
+using Octokit;
 
 namespace DotNet.GitHub
 {

--- a/src/DotNet.GitHub/IGitHubLabelService.cs
+++ b/src/DotNet.GitHub/IGitHubLabelService.cs
@@ -1,5 +1,8 @@
-﻿using Octokit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Threading.Tasks;
+using Octokit;
 
 namespace DotNet.GitHub
 {

--- a/src/DotNet.GitHub/IResilientGitHubClientFactory.cs
+++ b/src/DotNet.GitHub/IResilientGitHubClientFactory.cs
@@ -1,4 +1,7 @@
-﻿using Octokit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Octokit;
 
 namespace DotNet.GitHub
 {

--- a/src/DotNet.GitHub/ModelExtensions.cs
+++ b/src/DotNet.GitHub/ModelExtensions.cs
@@ -1,11 +1,14 @@
-﻿using DotNet.Extensions;
-using DotNet.Models;
-using Markdown;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using DotNet.Extensions;
+using DotNet.Models;
+using Markdown;
 
 namespace DotNet.GitHub
 {
@@ -223,7 +226,7 @@ namespace DotNet.GitHub
                 $"Create a file at the root of the repository, named *dotnet-versionsweeper.json* and " +
                 $"add an `ignore` entry following the " +
                 $"[globbing patterns detailed here](https://docs.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing.matcher#remarks).");
-            
+
             document.AppendCode("json", @"{
     ""ignore"": [
         ""**/Path/To/Example.csproj""
@@ -232,7 +235,7 @@ namespace DotNet.GitHub
 
             result =
                 (
-                    Title:"Upgrade project(s) to the SDK-style project format",
+                    Title: "Upgrade project(s) to the SDK-style project format",
                     MarkdownBody: document.ToString()
                 );
 

--- a/src/DotNet.GitHub/RateLimitAwareQueue.cs
+++ b/src/DotNet.GitHub/RateLimitAwareQueue.cs
@@ -1,7 +1,10 @@
-﻿using Octokit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Octokit;
 
 namespace DotNet.GitHub
 {

--- a/src/DotNet.GitHub/Records.cs
+++ b/src/DotNet.GitHub/Records.cs
@@ -1,4 +1,7 @@
-﻿namespace DotNet.GitHub
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DotNet.GitHub
 {
     public record GraphQLResult<T>
     {

--- a/src/DotNet.GitHub/ServiceCollectionExtensions.cs
+++ b/src/DotNet.GitHub/ServiceCollectionExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
 using Octokit.Extensions;
 
 namespace DotNet.GitHub

--- a/src/DotNet.GitHubActions/Commands.cs
+++ b/src/DotNet.GitHubActions/Commands.cs
@@ -1,4 +1,7 @@
-﻿namespace DotNet.GitHubActions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DotNet.GitHubActions
 {
     public static class Commands
     {

--- a/src/DotNet.GitHubActions/ExitCode.cs
+++ b/src/DotNet.GitHubActions/ExitCode.cs
@@ -1,4 +1,7 @@
-﻿namespace DotNet.GitHubActions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DotNet.GitHubActions
 {
     /// <summary>
     /// The code to exit an action

--- a/src/DotNet.GitHubActions/IJobService.cs
+++ b/src/DotNet.GitHubActions/IJobService.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/src/DotNet.GitHubActions/IJobService.cs
+++ b/src/DotNet.GitHubActions/IJobService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace DotNet.GitHubActions
@@ -8,7 +9,9 @@ namespace DotNet.GitHubActions
     /// </summary>
     public interface IJobService
     {
-        void ExportVariable(string name, object? value = default);
+        bool IsDebug();
+
+        void ExportVariable<T>(string name, T? value = default);
 
         void SetSecret(string secret);
 
@@ -16,21 +19,53 @@ namespace DotNet.GitHubActions
 
         string GetInput(string name, InputOptions? options = default);
 
-        void SetOutput(string name, object? value = default);
+        /// <summary>
+        /// Writes the given <paramref name="properties"/> and <paramref name="message"/> arguments
+        /// in the following format: "::set-output {properties}::{message}", for example:
+        /// "::set-output key-1=some initial value, key-2=anthor value::Hi friends!" when
+        /// <paramref name="message"/> is "Hi friends!" and <paramref name="properties"/> is 
+        /// new Dictionary{string, string} {  ["key-1"] = "some initial value", ["key-2"] = "another value" });
+        /// </summary>
+        /// <example>
+        /// <code language="c#">
+        /// <![CDATA[
+        /// IJobService job = new DefaultJobService();
+        ///
+        /// // ::set-output::Hi friends!
+        /// job.SetOutput("Hi friends");
+        /// 
+        /// // ::set-output prop1=Value 1, prop2=Value 2::
+        /// job.SetOutput(
+        ///      properties: new Dictionary<string, string>
+        ///      {
+        ///          ["prop1"] = "Value 1",
+        ///          ["prop2"] = "Value 2"
+        ///      });
+        ///
+        /// // ::set-output prop1=Value 1, prop2=Value 2::Hi friends!
+        /// job.SetOutput(
+        ///      message: "Hi friends",
+        ///      properties: new Dictionary<string, string>
+        ///      {
+        ///          ["prop1] = "Value 1",
+        ///          ["prop2"] = "Value 2"
+        ///      });
+        /// ]]>
+        /// </code>
+        /// </example>
+        void SetOutput(string? message, Dictionary<string, string>? properties = default);
 
         void SetCommandEcho(bool enabled);
 
-        void SetFailed(string message);
+        void SetFailed(string message, int? exitCode = null);
 
-        bool IsDebug();
+        void Debug(string? message);
 
-        void Debug(string message);
+        void Error(string? message);
 
-        void Error(string message);
+        void Warning(string? message);
 
-        void Warning(string message);
-
-        void Info(string message);
+        void Info(string? message);
 
         void StartGroup(string name);
 
@@ -53,7 +88,29 @@ namespace DotNet.GitHubActions
             return result;
         }
 
-        void SaveState(string name, object? value = default);
+        /// <summary>
+        /// Writes the given <paramref name="stateName"/> and <paramref name="state"/> arguments
+        /// in the following format: "::save-state name={stateName}::{state}", for example:
+        /// "::save-state name=state-7::The number seven" when
+        /// <paramref name="stateName"/> is "state-7" and <paramref name="state"/> is "The number seven"
+        /// </summary>
+        /// <example>
+        /// <code language="c#">
+        /// <![CDATA[
+        /// IJobService job = new DefaultJobService();
+        ///
+        /// // ::save-state name=state_1::Hi friends!
+        /// job.SaveState("state_1", "Hi friends");
+        ///
+        /// // ::save-state name=state_2::2
+        /// job.SaveState("state_2", 2);
+        ///
+        /// // ::save-state name=state_3::false
+        /// job.SaveState("state_3", false);
+        /// ]]>
+        /// </code>
+        /// </example>
+        void SaveState<T>(string stateName, T? state = default);
 
         string GetState(string name);
     }

--- a/src/DotNet.GitHubActions/InputOptions.cs
+++ b/src/DotNet.GitHubActions/InputOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace DotNet.GitHubActions
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DotNet.GitHubActions
 {
     public record InputOptions
     {

--- a/src/DotNet.GitHubActions/JobService.cs
+++ b/src/DotNet.GitHubActions/JobService.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/src/DotNet.GitHubActions/JobService.cs
+++ b/src/DotNet.GitHubActions/JobService.cs
@@ -7,6 +7,7 @@ namespace DotNet.GitHubActions
 {
     public class JobService : IJobService
     {
+        /// <inheritdoc />
         public void AddPath(string inputPath)
         {
             IssueCommand(Commands.AddPath, message: inputPath);
@@ -14,13 +15,29 @@ namespace DotNet.GitHubActions
                 "PATH", $"{inputPath}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}");
         }
 
-        public void Debug(string message) => IssueCommand(Commands.Debug, message: message);
+        /// <inheritdoc />
+        public bool IsDebug() => Environment.GetEnvironmentVariable("RUNNER_DEBUG") == "1";
+        /// <inheritdoc />
+        public void Info(string? message) => Console.WriteLine(message);
+        /// <inheritdoc />
+        public void Debug(string? message) => IssueCommand(Commands.Debug, message: message);
+        /// <inheritdoc />
+        public void Error(string? message) => IssueCommand(Commands.Error, message: message);
+        /// <inheritdoc />
+        public void Warning(string? message) => IssueCommand(Commands.Warning, message: message);
+        /// <inheritdoc />
+        public void SetSecret(string secret) => IssueCommand(Commands.AddMask, message: secret);
+        /// <inheritdoc />
+        public void StartGroup(string name) => IssueCommand(Commands.Group, message: name);
+        /// <inheritdoc />
+        public void EndGroup() => IssueCommand<object>(Commands.EndGroup);
+        /// <inheritdoc />
+        public void SetCommandEcho(bool enabled) => IssueCommand(Commands.Echo, message: enabled ? "on" : "off");
+        /// <inheritdoc />
+        public string GetState(string name) => Environment.GetEnvironmentVariable($"STATE_{name}") ?? "";
 
-        public void EndGroup() => IssueCommand(Commands.EndGroup);
-
-        public void Error(string message) => IssueCommand(Commands.Error, message: message);
-
-        public void ExportVariable(string name, object? value)
+        /// <inheritdoc />
+        public void ExportVariable<T>(string name, T? value)
         {
             var convertedValue = value.ToCommandValue();
             Environment.SetEnvironmentVariable(name, convertedValue);
@@ -38,6 +55,7 @@ namespace DotNet.GitHubActions
             }
         }
 
+        /// <inheritdoc />
         public string GetInput(string name, InputOptions? options = default)
         {
             var value = Environment.GetEnvironmentVariable(
@@ -48,44 +66,27 @@ namespace DotNet.GitHubActions
                 : value.Trim();
         }
 
-        public string GetState(string name) =>
-            Environment.GetEnvironmentVariable($"STATE_{name}") ?? "";
+        /// <inheritdoc />
+        public void SaveState<T>(string stateName, T? stateValue) =>
+            IssueCommand(Commands.SaveState, new() { ["name"] = stateName }, stateValue);
 
-        public void Info(string message) => Console.WriteLine(message);
-
-        public bool IsDebug() => Environment.GetEnvironmentVariable("RUNNER_DEBUG") == "1";
-
-        public void SaveState(string name, object? value) =>
-            IssueCommand(Commands.SaveState, new Dictionary<string, string>() { [nameof(name)] = name }, value);
-
-        public void SetCommandEcho(bool enabled) =>
-            IssueCommand(Commands.Echo, message: enabled ? "on" : "off");
-
-        public void SetFailed(string message)
+        /// <inheritdoc />
+        public void SetFailed(string message, int? exitCode = null)
         {
             Error(message);
-
-            Environment.Exit((int)ExitCode.Failure);
+            Environment.Exit(exitCode ?? (int)ExitCode.Failure);
         }
 
-        public void SetOutput(string name, object? value) =>
-            IssueCommand(Commands.SetOutput, new Dictionary<string, string>() { [nameof(name)] = name }, value);
+        /// <inheritdoc />
+        public void SetOutput(string? message, Dictionary<string, string>? properties = default) =>
+            IssueCommand(Commands.SetOutput, properties, message);
 
-        public void SetSecret(string secret) =>
-            IssueCommand(Commands.AddMask, message: secret);
-
-        public void StartGroup(string name) =>
-            IssueCommand(Commands.Group, message: name);
-
-        public void Warning(string message) =>
-            IssueCommand(Commands.Warning, message: message);
-
-        static void IssueCommand(
-            string command,
-            IDictionary<string, string>? commandProperties = default,
-            object? message = default)
+        static void IssueCommand<T>(
+            string commandName,
+            Dictionary<string, string>? properties = default,
+            T? message = default)
         {
-            WorkflowCommand workflowCommand = new(command, message, commandProperties);
+            WorkflowCommand<T> workflowCommand = new(commandName, message, properties);
             Console.WriteLine(workflowCommand.ToString());
         }
 

--- a/src/DotNet.GitHubActions/ServiceCollectionExtensions.cs
+++ b/src/DotNet.GitHubActions/ServiceCollectionExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotNet.GitHubActions
 {

--- a/src/DotNet.GitHubActions/WorkflowCommand.cs
+++ b/src/DotNet.GitHubActions/WorkflowCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/DotNet.GitHubActions/WorkflowCommand.cs
+++ b/src/DotNet.GitHubActions/WorkflowCommand.cs
@@ -8,27 +8,48 @@ using System.Text.Json.Serialization;
 
 namespace DotNet.GitHubActions
 {
-    public record WorkflowCommand(
-        string Command,
-        object? Message,
+    /// <summary>
+    /// {commandName} is the command name, example:
+    ///     "::set-output::"
+    ///     "::{commandName}::"
+    ///      when {commandName} is "set-output"
+    /// {message} is a string, example:
+    ///     "::set-output::Hello World!"
+    ///     "::set-output::{message}"
+    ///     when {message} is "Hello World!"
+    /// {properties} is a Dictionary{string, string}, example:
+    ///     "::set-output prop1=Value 1, value 2::Hi"
+    ///     "::set-output {properties}::{message}"
+    ///     when {message} is "Hi"
+    ///     and {properties} is
+    ///         new Dictionary{string, string}
+    ///         {
+    ///             ["prop1] = "Value 1",
+    ///             ["prop2"] = "Value 2"
+    ///         }
+    /// ::{commandName} {properties}::{message}
+    /// </summary>
+    public record WorkflowCommand<T>(
+        string CommandName,
+        T? Message,
         IDictionary<string, string>? CommandProperties = default)
     {
         const string CMD_STRING = "::";
 
         public override string ToString()
         {
-            StringBuilder builder = new($"{CMD_STRING}{Command}");
+            StringBuilder builder = new($"{CMD_STRING}{CommandName}");
 
             if (CommandProperties?.Any() ?? false)
             {
-                foreach (var (first, key, value) 
+                foreach (var (first, key, value)
                     in CommandProperties.Select((kvp, i) => (i == 0, kvp.Key, kvp.Value)))
                 {
                     if (!first)
                     {
                         builder.Append(',');
                     }
-                    builder.Append($"{key}={EscapeProperty(value)}");
+                    builder.Append($" {key}={EscapeProperty(value)}");
                 }
             }
 
@@ -37,13 +58,13 @@ namespace DotNet.GitHubActions
             return builder.ToString();
         }
 
-        static string EscapeData(object? value) =>
+        static string EscapeData<TSource>(TSource? value) =>
             value.ToCommandValue()
                 .Replace("%", "%25")
                 .Replace("\r", "%0D")
                 .Replace("\n", "%0A");
 
-        static string EscapeProperty(object? value) =>
+        static string EscapeProperty<TSource>(TSource? value) =>
             value.ToCommandValue()
                 .Replace("%", "%25")
                 .Replace("\r", "%0D")
@@ -63,6 +84,7 @@ namespace DotNet.GitHubActions
 
         internal static string ToCommandValue<T>(this T? value) => value switch
         {
+            null => string.Empty,
             string str => str,
             _ => JsonSerializer.Serialize(value, _lazyOptions.Value)
         };

--- a/src/DotNet.IO/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DotNet.IO/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,7 @@
-﻿using DotNet.IO;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using DotNet.IO;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/DotNet.IO/Project/IProjectFileReader.cs
+++ b/src/DotNet.IO/Project/IProjectFileReader.cs
@@ -1,5 +1,8 @@
-﻿using DotNet.Models;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Threading.Tasks;
+using DotNet.Models;
 
 namespace DotNet.IO
 {

--- a/src/DotNet.IO/Project/ProjectFileReader.cs
+++ b/src/DotNet.IO/Project/ProjectFileReader.cs
@@ -1,9 +1,12 @@
-﻿using DotNet.Extensions;
-using DotNet.Models;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using DotNet.Extensions;
+using DotNet.Models;
 using SystemFile = System.IO.File;
 
 namespace DotNet.IO
@@ -76,7 +79,7 @@ namespace DotNet.IO
             if (json is { Length: > 0 })
             {
                 var lines = json.Split('\n');
-                for (var i = 0; i < lines.Length; ++ i)
+                for (var i = 0; i < lines.Length; ++i)
                 {
                     if (lines[i]?.Contains(tfm, StringComparison.OrdinalIgnoreCase) ?? false)
                     {
@@ -104,9 +107,9 @@ namespace DotNet.IO
         static int GetLineNumberFromIndex(string xml, int index)
         {
             var lineNumber = 1;
-            for (var i = 0; i < index; ++ i)
+            for (var i = 0; i < index; ++i)
             {
-                if (xml[i] == '\n') ++ lineNumber;
+                if (xml[i] == '\n') ++lineNumber;
             }
             return lineNumber;
         }

--- a/src/DotNet.IO/Project/ProjectJson.cs
+++ b/src/DotNet.IO/Project/ProjectJson.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace DotNet.IO

--- a/src/DotNet.IO/Solution/ISolutionFileReader.cs
+++ b/src/DotNet.IO/Solution/ISolutionFileReader.cs
@@ -1,5 +1,8 @@
-﻿using DotNet.Models;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Threading.Tasks;
+using DotNet.Models;
 
 namespace DotNet.IO
 {

--- a/src/DotNet.IO/Solution/SolutionFileReader.cs
+++ b/src/DotNet.IO/Solution/SolutionFileReader.cs
@@ -1,7 +1,10 @@
-﻿using DotNet.Models;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using DotNet.Models;
 using SystemFile = System.IO.File;
 
 namespace DotNet.IO
@@ -34,7 +37,7 @@ namespace DotNet.IO
                 var solutionDirectory = Path.GetDirectoryName(solution.FullPath);
                 var solutionText = await SystemFile.ReadAllTextAsync(solution.FullPath);
                 var matches = _solutionProjectsExpression.Matches(solutionText);
-                
+
                 foreach (Match match in matches)
                 {
                     var path = match.Groups["Path"].Value;

--- a/src/DotNet.Models/FrameworkRelease.cs
+++ b/src/DotNet.Models/FrameworkRelease.cs
@@ -1,6 +1,9 @@
-﻿using DotNet.Extensions;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
+using DotNet.Extensions;
 using Microsoft.Deployment.DotNet.Releases;
 
 namespace DotNet.Models

--- a/src/DotNet.Models/IRelease.cs
+++ b/src/DotNet.Models/IRelease.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using Microsoft.Deployment.DotNet.Releases;
 
 namespace DotNet.Models

--- a/src/DotNet.Models/Project.cs
+++ b/src/DotNet.Models/Project.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using SystemPath = System.IO.Path;
 
 namespace DotNet.Models

--- a/src/DotNet.Models/ProjectSupportReport.cs
+++ b/src/DotNet.Models/ProjectSupportReport.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 
 namespace DotNet.Models
 {

--- a/src/DotNet.Models/ReleaseFactory.cs
+++ b/src/DotNet.Models/ReleaseFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using Microsoft.Deployment.DotNet.Releases;
 
 namespace DotNet.Models

--- a/src/DotNet.Models/Solution.cs
+++ b/src/DotNet.Models/Solution.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 
 namespace DotNet.Models
 {

--- a/src/DotNet.Models/SolutionSupportReport.cs
+++ b/src/DotNet.Models/SolutionSupportReport.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 
 namespace DotNet.Models
 {

--- a/src/DotNet.Releases/Core/CoreReleaseIndexService.cs
+++ b/src/DotNet.Releases/Core/CoreReleaseIndexService.cs
@@ -1,8 +1,11 @@
-﻿using DotNet.Extensions;
-using Microsoft.Deployment.DotNet.Releases;
-using Microsoft.Extensions.Caching.Memory;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DotNet.Extensions;
+using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace DotNet.Releases
 {

--- a/src/DotNet.Releases/Core/ICoreReleaseIndexService.cs
+++ b/src/DotNet.Releases/Core/ICoreReleaseIndexService.cs
@@ -1,7 +1,10 @@
-﻿using Microsoft.Deployment.DotNet.Releases;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Deployment.DotNet.Releases;
 
 namespace DotNet.Releases
 {

--- a/src/DotNet.Releases/Extensions/DateTimeExtensions.cs
+++ b/src/DotNet.Releases/Extensions/DateTimeExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 
 namespace DotNet.Releases.Extensions
 {

--- a/src/DotNet.Releases/Extensions/ProductExtensions.cs
+++ b/src/DotNet.Releases/Extensions/ProductExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Deployment.DotNet.Releases;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Deployment.DotNet.Releases;
 
 namespace DotNet.Releases.Extensions
 {
@@ -7,11 +10,11 @@ namespace DotNet.Releases.Extensions
         public static string GetTargetFrameworkMoniker(this Product product) =>
             product is not null
                 ? product.ProductName switch
-                  {
-                      ".NET" => $"net{product.ProductVersion}",
-                      ".NET Core" => $"netcoreapp{product.ProductVersion}",
-                      _ => product.ProductVersion
-                  }
+                {
+                    ".NET" => $"net{product.ProductVersion}",
+                    ".NET Core" => $"netcoreapp{product.ProductVersion}",
+                    _ => product.ProductVersion
+                }
                 : string.Empty;
     }
 }

--- a/src/DotNet.Releases/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DotNet.Releases/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,7 @@
-﻿using DotNet.Releases;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using DotNet.Releases;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/DotNet.Releases/Framework/FrameworkReleaseIndexService.cs
+++ b/src/DotNet.Releases/Framework/FrameworkReleaseIndexService.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 
 namespace DotNet.Releases
 {

--- a/src/DotNet.Releases/Framework/FrameworkReleaseService.cs
+++ b/src/DotNet.Releases/Framework/FrameworkReleaseService.cs
@@ -1,9 +1,12 @@
-﻿using DotNet.Extensions;
-using DotNet.Models;
-using Microsoft.Extensions.Caching.Memory;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using DotNet.Extensions;
+using DotNet.Models;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace DotNet.Releases
 {

--- a/src/DotNet.Releases/Framework/IFrameworkReleaseIndexService.cs
+++ b/src/DotNet.Releases/Framework/IFrameworkReleaseIndexService.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 
 namespace DotNet.Releases
 {

--- a/src/DotNet.Releases/Framework/IFrameworkReleaseService.cs
+++ b/src/DotNet.Releases/Framework/IFrameworkReleaseService.cs
@@ -1,9 +1,12 @@
-﻿using DotNet.Models;
-using Microsoft.Deployment.DotNet.Releases;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DotNet.Models;
+using Microsoft.Deployment.DotNet.Releases;
 
 namespace DotNet.Releases
 {

--- a/src/DotNet.Releases/LabeledVersion.cs
+++ b/src/DotNet.Releases/LabeledVersion.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 
 namespace DotNet.Releases
 {
@@ -47,13 +50,13 @@ namespace DotNet.Releases
         public static bool operator >=(LabeledVersion? v1, LabeledVersion? v2) =>
             v1?._parsedVersion >= v2?._parsedVersion;
 
-        public static bool operator !=(LabeledVersion? v1, LabeledVersion? v2) => 
+        public static bool operator !=(LabeledVersion? v1, LabeledVersion? v2) =>
             v1?._parsedVersion != v2?._parsedVersion;
 
-        public static bool operator <(LabeledVersion? v1, LabeledVersion? v2) => 
+        public static bool operator <(LabeledVersion? v1, LabeledVersion? v2) =>
             v1?._parsedVersion < v2?._parsedVersion;
 
-        public static bool operator <=(LabeledVersion? v1, LabeledVersion? v2) => 
+        public static bool operator <=(LabeledVersion? v1, LabeledVersion? v2) =>
             v1?._parsedVersion <= v2?._parsedVersion;
 
         int IComparable<LabeledVersion?>.CompareTo(LabeledVersion? other) =>
@@ -62,7 +65,7 @@ namespace DotNet.Releases
 
         public override bool Equals(object? obj) =>
             ReferenceEquals(this, obj)
-            || obj is not null 
+            || obj is not null
             && obj is LabeledVersion other
             && _parsedVersion == other._parsedVersion
             && Label == other.Label;

--- a/src/DotNet.Releases/Reporting/IUnsupportedProjectReporter.cs
+++ b/src/DotNet.Releases/Reporting/IUnsupportedProjectReporter.cs
@@ -1,5 +1,8 @@
-﻿using DotNet.Models;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Generic;
+using DotNet.Models;
 
 namespace DotNet.Releases
 {

--- a/src/DotNet.Releases/Reporting/UnsupportedProjectReporter.cs
+++ b/src/DotNet.Releases/Reporting/UnsupportedProjectReporter.cs
@@ -1,10 +1,13 @@
-﻿using DotNet.Models;
-using DotNet.Releases.Extensions;
-using Microsoft.Deployment.DotNet.Releases;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DotNet.Models;
+using DotNet.Releases.Extensions;
+using Microsoft.Deployment.DotNet.Releases;
 
 namespace DotNet.Releases
 {

--- a/src/DotNet.Releases/TargetFrameworkMonikerMap.cs
+++ b/src/DotNet.Releases/TargetFrameworkMonikerMap.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using DotNet.Extensions;
 

--- a/src/DotNet.Reporter/Program.cs
+++ b/src/DotNet.Reporter/Program.cs
@@ -1,10 +1,13 @@
-﻿using DotNet.IO;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using DotNet.IO;
 using DotNet.Releases;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Linq;
 
 using var host = Host.CreateDefaultBuilder(args)
     .ConfigureLogging((_, logging) => logging.ClearProviders())

--- a/src/DotNet.VersionSweeper/ActionType.cs
+++ b/src/DotNet.VersionSweeper/ActionType.cs
@@ -1,4 +1,7 @@
-﻿namespace DotNet.VersionSweeper
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DotNet.VersionSweeper
 {
     public enum ActionType
     {

--- a/src/DotNet.VersionSweeper/Discovery.cs
+++ b/src/DotNet.VersionSweeper/Discovery.cs
@@ -1,14 +1,17 @@
-﻿using DotNet.Extensions;
-using DotNet.GitHubActions;
-using DotNet.IO;
-using DotNet.Models;
-using Microsoft.Extensions.FileSystemGlobbing;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using DotNet.Extensions;
+using DotNet.GitHubActions;
+using DotNet.IO;
+using DotNet.Models;
+using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace DotNet.VersionSweeper
 {

--- a/src/DotNet.VersionSweeper/EnvironmentVariableNames.cs
+++ b/src/DotNet.VersionSweeper/EnvironmentVariableNames.cs
@@ -1,4 +1,7 @@
-﻿namespace DotNet.VersionSweeper
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DotNet.VersionSweeper
 {
     public static class EnvironmentVariableNames
     {
@@ -6,7 +9,7 @@
         {
             public const string Token = "GITHUB_TOKEN";
         }
-        
+
         public static class Sweeper
         {
             public const string Owner = "OWNER";

--- a/src/DotNet.VersionSweeper/Options.cs
+++ b/src/DotNet.VersionSweeper/Options.cs
@@ -1,5 +1,8 @@
-﻿using CommandLine;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
+using CommandLine;
 using static System.Environment;
 using static DotNet.VersionSweeper.EnvironmentVariableNames;
 

--- a/src/DotNet.VersionSweeper/OptionsExtensions.cs
+++ b/src/DotNet.VersionSweeper/OptionsExtensions.cs
@@ -56,14 +56,14 @@ namespace DotNet.VersionSweeper
             job.SetCommandEcho(true);
 
             StringBuilder builder = new();
-            builder.Append($"repository owner: {options.Owner}");
-            builder.Append($"repository name: {options.Name}");
-            builder.Append($"current branch: {options.Branch}");
-            builder.Append($"root directory to search: {options.Directory}");
+            builder.AppendLine($"repository owner: {options.Owner}");
+            builder.AppendLine($"repository name: {options.Name}");
+            builder.AppendLine($"current branch: {options.Branch}");
+            builder.AppendLine($"root directory to search: {options.Directory}");
             var parsedPatterns = string.Join(", ",
                 options.SearchPattern?.SplitOnExpectedDelimiters().AsRecursivePatterns() ?? Array.Empty<string>());
-            builder.Append($"parsed patterns: {parsedPatterns}");
-            builder.Append($"report non-SDK style projects: {options.ReportNonSdkStyleProjects}");
+            builder.AppendLine($"parsed patterns: {parsedPatterns}");
+            builder.AppendLine($"report non-SDK style projects: {options.ReportNonSdkStyleProjects}");
 
             job.Info(builder.ToString());
         }

--- a/src/DotNet.VersionSweeper/OptionsExtensions.cs
+++ b/src/DotNet.VersionSweeper/OptionsExtensions.cs
@@ -1,10 +1,13 @@
-﻿using DotNet.GitHubActions;
-using Microsoft.Extensions.FileSystemGlobbing;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using DotNet.GitHubActions;
+using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace DotNet.VersionSweeper
 {

--- a/src/DotNet.VersionSweeper/Program.cs
+++ b/src/DotNet.VersionSweeper/Program.cs
@@ -1,4 +1,11 @@
-﻿using CommandLine;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CommandLine;
 using DotNet.GitHub;
 using DotNet.GitHubActions;
 using DotNet.Models;
@@ -7,10 +14,6 @@ using DotNet.VersionSweeper;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Octokit;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using static CommandLine.Parser;
 using Project = DotNet.Models.Project;
 

--- a/src/DotNet.VersionSweeper/ServiceProviderExtensions.cs
+++ b/src/DotNet.VersionSweeper/ServiceProviderExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DotNet.VersionSweeper

--- a/src/DotNet.VersionSweeper/VersionSweeperConfig.cs
+++ b/src/DotNet.VersionSweeper/VersionSweeperConfig.cs
@@ -1,10 +1,13 @@
-﻿using DotNet.Extensions;
-using DotNet.GitHubActions;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.IO;
 using System.Linq;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using DotNet.Extensions;
+using DotNet.GitHubActions;
 
 namespace DotNet.VersionSweeper
 {

--- a/test/DotNet.ExtensionsTests/ObjectExtensionsTests.cs
+++ b/test/DotNet.ExtensionsTests/ObjectExtensionsTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Xunit;
@@ -78,7 +81,7 @@ namespace DotNet.Extensions.Tests
     enum TestEnum
     {
         Zero = 0,
-        
+
         One = 1,
         ButThisIsAlsoOne = 1,
 

--- a/test/DotNet.ExtensionsTests/StringExtensionsTests.cs
+++ b/test/DotNet.ExtensionsTests/StringExtensionsTests.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
 using Xunit;
 
 namespace DotNet.Extensions.Tests

--- a/test/DotNet.GitHubActionsTests/DotNet.GitHubActionsTests.csproj
+++ b/test/DotNet.GitHubActionsTests/DotNet.GitHubActionsTests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>.NETCoreApp,Version=v5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DotNet.GitHubActions\DotNet.GitHubActions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/DotNet.GitHubActionsTests/JobServiceTests.cs
+++ b/test/DotNet.GitHubActionsTests/JobServiceTests.cs
@@ -1,0 +1,178 @@
+﻿using DotNet.GitHubActions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace DotNet.GitHubActionsTests
+{
+    public sealed class JobServiceTests : IDisposable
+    {
+        static readonly TextWriter s_consoleOut = Console.Out;
+
+        public static IEnumerable<object[]> WriteSaveStateInput = new[]
+        {
+            new object[]
+            {
+                "test-state",
+                2,
+                new[]
+                {
+                    $"::{Commands.SaveState} name=test-state::2"
+                }
+            },
+            new object[]
+            {
+                "pickle",
+                "chips",
+                new[]
+                {
+                    $"::{Commands.SaveState} name=pickle::chips"
+                }
+            }
+        };
+
+        [
+            Theory,
+            MemberData(nameof(WriteSaveStateInput))
+        ]
+        public void WriteSaveStateCommandTest<T>(
+            string stateName,
+            T stateValue,
+            string[] expectedCommands)
+        {
+            var interceptor = InterceptOut();
+            IJobService sut = new JobService();
+
+            sut.SaveState(stateName, stateValue);
+
+            AssertCommand(
+                interceptor,
+                expectedCommands);
+        }
+
+        public static IEnumerable<object[]> WriteSetOutputInput = new[]
+        {
+            new object[]
+            {
+                null,
+                "deftones",
+                new[]
+                {
+                    $"::{Commands.SetOutput}::deftones"
+                }
+            },
+            new object[]
+            {
+                null,
+                "percent % percent % cr \r cr \r lf \n lf \n",
+                new[]
+                {
+                    $"::{Commands.SetOutput}::percent %25 percent %25 cr %0D cr %0D lf %0A lf %0A"
+                }
+            },
+            new object[]
+            {
+                null,
+                "%25 %25 %0D %0D %0A %0A %3A %3A %2C %2C",
+                new[]
+                {
+                    $"::{Commands.SetOutput}::%2525 %2525 %250D %250D %250A %250A %253A %253A %252C %252C"
+                }
+            },
+            new object[]
+            {
+                new Dictionary<string, string>
+                {
+                    ["prop1"] = "Value 1",
+                    ["prop2"] = "Value 2"
+                },
+                "example",
+                new[]
+                {
+                    $"::{Commands.SetOutput} prop1=Value 1, prop2=Value 2::example"
+                }
+            }
+        };
+
+        [
+            Theory,
+            MemberData(nameof(WriteSetOutputInput))
+        ]
+        public void WriteSetOutputCommandTest(
+            Dictionary<string, string> properties,
+            string message,
+            string[] expectedCommands)
+        {
+            var interceptor = InterceptOut();
+            IJobService sut = new JobService();
+
+            sut.SetOutput(message, properties);
+
+            AssertCommand(
+                interceptor,
+                expectedCommands);
+        }
+
+        [Fact]
+        public void WriteWarningMessageTest()
+        {
+            var interceptor = InterceptOut();
+            IJobService sut = new JobService();
+            sut.Warning("Um, not sure....but something feels off!");
+
+            AssertCommand(
+                interceptor,
+                new[] { "::warning::Um, not sure....but something feels off!" });
+        }
+
+        [Fact]
+        public void WriteDebugMessageTest()
+        {
+            var interceptor = InterceptOut();
+            IJobService sut = new JobService();
+            sut.Debug("Does this really work?");
+
+            AssertCommand(
+                interceptor,
+                new[] { "::debug::Does this really work?" });
+        }
+
+        [Fact]
+        public void GroupMessagesTest()
+        {
+            var interceptor = InterceptOut();
+            IJobService sut = new JobService();
+            sut.StartGroup("example");
+            sut.Info("Testing... 1, 2, free?!");
+            sut.EndGroup();
+
+            AssertCommand(
+                interceptor,
+                new[] { "::group::example", "Testing... 1, 2, free?!", "::endgroup::" });
+        }
+
+        static StringWriter InterceptOut()
+        {
+            StringWriter interceptor = new();
+            Console.SetOut(interceptor);
+
+            return interceptor;
+        }
+
+        static void AssertCommand(StringWriter writer, string[] expectedCommands)
+        {
+            var actualCommands =
+                writer.ToString()
+                    .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(expectedCommands.Length, actualCommands.Length);
+
+            for (var i = 0; i < expectedCommands.Length; ++i)
+            {
+                Assert.Equal(expectedCommands[i], actualCommands[i]);
+            }
+        }
+
+        public void Dispose() => Console.SetOut(s_consoleOut);
+    }
+}

--- a/test/DotNet.GitHubActionsTests/JobServiceTests.cs
+++ b/test/DotNet.GitHubActionsTests/JobServiceTests.cs
@@ -1,7 +1,10 @@
-﻿using DotNet.GitHubActions;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
+using DotNet.GitHubActions;
 using Xunit;
 
 namespace DotNet.GitHubActionsTests

--- a/test/DotNet.GitHubActionsTests/WorkflowCommandTests.cs
+++ b/test/DotNet.GitHubActionsTests/WorkflowCommandTests.cs
@@ -1,0 +1,44 @@
+﻿using DotNet.GitHubActions;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DotNet.GitHubActionsTests
+{
+    public class WorkflowCommandTests
+    {
+        public static IEnumerable<object[]> WorkflowCommandToStringInput = new[]
+{
+            new object[]
+            {
+                "some-name", 7, null, "::some-name::7"
+            },
+            new object[]
+            {
+                "another-name", true, null, "::another-name::true"
+            },
+            new object[]
+            {
+                "cmdr", false, new Dictionary<string, string> { ["k1"] = "v1" }, "::cmdr k1=v1::false"
+            },
+            new object[]
+            {
+                "~~~", "Hi friends!", null, "::~~~::Hi friends!"
+            },
+            new object[]
+            {
+                null, null, null, "::::"
+            }
+        };
+
+        [
+            Theory,
+            MemberData(nameof(WorkflowCommandToStringInput))
+        ]
+        public void WorkflowCommandToStringTest<T>(
+            string name, T message, Dictionary<string, string> properties, string expected)
+        {
+            WorkflowCommand<T> command = new(name, message, properties);
+            Assert.Equal(expected, command.ToString());
+        }
+    }
+}

--- a/test/DotNet.GitHubActionsTests/WorkflowCommandTests.cs
+++ b/test/DotNet.GitHubActionsTests/WorkflowCommandTests.cs
@@ -1,5 +1,8 @@
-﻿using DotNet.GitHubActions;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Generic;
+using DotNet.GitHubActions;
 using Xunit;
 
 namespace DotNet.GitHubActionsTests

--- a/test/DotNet.GitHubTests/GitHubLabelServiceTests.cs
+++ b/test/DotNet.GitHubTests/GitHubLabelServiceTests.cs
@@ -1,13 +1,16 @@
-﻿using DotNet.GitHub;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DotNet.GitHub;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Octokit;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace DotNet.GitHubTests

--- a/test/DotNet.GitHubTests/GraphQLRequestTests.cs
+++ b/test/DotNet.GitHubTests/GraphQLRequestTests.cs
@@ -1,10 +1,13 @@
-﻿using DotNet.Extensions;
-using DotNet.GitHub;
-using Octokit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using DotNet.Extensions;
+using DotNet.GitHub;
+using Octokit;
 using Xunit;
 
 namespace DotNet.GitHubTests

--- a/test/DotNet.IOTests/Constants.cs
+++ b/test/DotNet.IOTests/Constants.cs
@@ -1,4 +1,7 @@
-﻿namespace DotNet.IOTests
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DotNet.IOTests
 {
     class Constants
     {

--- a/test/DotNet.IOTests/Project/ProjectFileReaderTests.cs
+++ b/test/DotNet.IOTests/Project/ProjectFileReaderTests.cs
@@ -1,6 +1,9 @@
-﻿using DotNet.IO;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.IO;
 using System.Threading.Tasks;
+using DotNet.IO;
 using Xunit;
 
 namespace DotNet.IOTests
@@ -48,7 +51,7 @@ namespace DotNet.IOTests
                 var project = await sut.ReadProjectAsync(projectPath);
                 Assert.Equal(expectedLineNumber, project.TfmLineNumber);
                 Assert.Equal(expectedTfms.Length, project.Tfms.Length);
-                for (var i = 0; i < expectedTfms.Length; ++ i)
+                for (var i = 0; i < expectedTfms.Length; ++i)
                 {
                     Assert.Equal(expectedTfms[i], project.Tfms[i]);
                 }

--- a/test/DotNet.IOTests/Solution/SolutionFileReaderTests.cs
+++ b/test/DotNet.IOTests/Solution/SolutionFileReaderTests.cs
@@ -1,8 +1,11 @@
-﻿using DotNet.IO;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using DotNet.IO;
 using Xunit;
 
 namespace DotNet.IOTests

--- a/test/DotNet.ModelsTests/FrameworkReleaseTests.cs
+++ b/test/DotNet.ModelsTests/FrameworkReleaseTests.cs
@@ -1,4 +1,7 @@
-﻿using DotNet.Models;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using DotNet.Models;
 using Xunit;
 
 namespace DotNet.ModelsTests

--- a/test/DotNet.ModelsTests/ProjectTests.cs
+++ b/test/DotNet.ModelsTests/ProjectTests.cs
@@ -1,6 +1,9 @@
-﻿using DotNet.Models;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
+using DotNet.Models;
 using Xunit;
 
 namespace DotNet.ModelsTests

--- a/test/DotNet.ModelsTests/ReleaseFactoryTests.cs
+++ b/test/DotNet.ModelsTests/ReleaseFactoryTests.cs
@@ -1,6 +1,9 @@
-﻿using Xunit;
-using Microsoft.Deployment.DotNet.Releases;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using DotNet.Models;
+using Microsoft.Deployment.DotNet.Releases;
+using Xunit;
 
 namespace DotNet.ModelsTests
 {

--- a/test/DotNet.ReleasesTests/Core/CoreReleaseIndexServiceTests.cs
+++ b/test/DotNet.ReleasesTests/Core/CoreReleaseIndexServiceTests.cs
@@ -1,11 +1,14 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Threading.Tasks;
+using DotNet.Extensions;
+using DotNet.Releases;
+using DotNet.Releases.Extensions;
+using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
-using DotNet.Extensions;
-using Microsoft.Deployment.DotNet.Releases;
-using DotNet.Releases.Extensions;
-using DotNet.Releases;
+using Xunit;
 
 namespace DotNet.ReleasesTests
 {

--- a/test/DotNet.ReleasesTests/Framework/FrameworkReleaseServiceTests.cs
+++ b/test/DotNet.ReleasesTests/Framework/FrameworkReleaseServiceTests.cs
@@ -1,8 +1,11 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Threading.Tasks;
+using DotNet.Releases;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
-using DotNet.Releases;
+using Xunit;
 
 namespace DotNet.ReleasesTests
 {

--- a/test/DotNet.ReleasesTests/LabeledVersionTests.cs
+++ b/test/DotNet.ReleasesTests/LabeledVersionTests.cs
@@ -1,6 +1,9 @@
-﻿using DotNet.Releases;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
+using DotNet.Releases;
 using Xunit;
 
 namespace DotNet.ReleasesTests

--- a/test/DotNet.VersionSweeperTests/OptionsTests.cs
+++ b/test/DotNet.VersionSweeperTests/OptionsTests.cs
@@ -1,7 +1,10 @@
-﻿using Xunit;
-using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
+using System.Collections.Generic;
 using DotNet.VersionSweeper;
+using Xunit;
 
 namespace DotNet.VersionSweeperTests
 {
@@ -27,7 +30,7 @@ namespace DotNet.VersionSweeperTests
             {
                 SearchPattern = inputPattern
             };
-            
+
             Assert.Equal(
                 expectedPatterns,
                 options.SearchPattern

--- a/test/DotNet.VersionSweeperTests/StringExtensionsTests.cs
+++ b/test/DotNet.VersionSweeperTests/StringExtensionsTests.cs
@@ -1,7 +1,10 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using DotNet.VersionSweeper;
+using Xunit;
 
 namespace DotNet.VersionSweeperTests
 {


### PR DESCRIPTION
- Add new line between each option/debug detail.
- Add unit tests for GitHub action class lib.
- Use generics `<TSource>` instead of `object`
- Add XML comments to confusing code
- Restructure class for readability
- Update *.editorconfig* with the one from the dotnet/runtime
- Run `dotnet format`
- Add license file headers to source