### PR TITLE
Do not create issue when unable to determine if issue already exists

### DIFF
--- a/src/DotNet.GitHub/GitHubGraphQLClient.cs
+++ b/src/DotNet.GitHub/GitHubGraphQLClient.cs
@@ -68,6 +68,7 @@ namespace DotNet.GitHub
                 request.Headers.Add("Accepts", MediaTypeNames.Application.Json);
 
                 using var response = await _httpClient.PostAsync(_graphQLUri, request);
+                response.EnsureSuccessStatusCode();
 
                 var json = await response.Content.ReadAsStringAsync();
                 var result = json.FromJson<GraphQLResult<ExistingIssue>>(_options);

--- a/src/DotNet.GitHub/GitHubGraphQLClient.cs
+++ b/src/DotNet.GitHub/GitHubGraphQLClient.cs
@@ -33,7 +33,7 @@ namespace DotNet.GitHub
 }";
 
         readonly Uri _graphQLUri = new("https://api.github.com/graphql");
-        readonly static JsonSerializerOptions _options = new()
+        readonly static JsonSerializerOptions s_options = new()
         {
             Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
             PropertyNameCaseInsensitive = true
@@ -45,7 +45,7 @@ namespace DotNet.GitHub
         public GitHubGraphQLClient(HttpClient httpClient, ILogger<GitHubGraphQLClient> logger) =>
             (_httpClient, _logger) = (httpClient, logger);
 
-        public async Task<ExistingIssue?> GetIssueAsync(
+        public async Task<(bool IsError, ExistingIssue? Issue)> GetIssueAsync(
             string owner, string name, string token, string title)
         {
             try
@@ -71,12 +71,12 @@ namespace DotNet.GitHub
                 response.EnsureSuccessStatusCode();
 
                 var json = await response.Content.ReadAsStringAsync();
-                var result = json.FromJson<GraphQLResult<ExistingIssue>>(_options);
+                var result = json.FromJson<GraphQLResult<ExistingIssue>>(s_options);
 
-                return result?.Data?.Search?.Nodes
+                return (false, result?.Data?.Search?.Nodes
                     ?.Where(i => i.State == ItemState.Open)
                     ?.OrderByDescending(i => i.CreatedAt.GetValueOrDefault())
-                    ?.FirstOrDefault();
+                    ?.FirstOrDefault());
             }
             catch (Exception ex)
             {

--- a/src/DotNet.GitHub/GitHubGraphQLClient.cs
+++ b/src/DotNet.GitHub/GitHubGraphQLClient.cs
@@ -82,7 +82,7 @@ namespace DotNet.GitHub
             {
                 _logger.LogWarning(ex, ex.Message);
 
-                return default;
+                return (true, default);
             }
         }
     }

--- a/src/DotNet.GitHub/GitHubLabelService.cs
+++ b/src/DotNet.GitHub/GitHubLabelService.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Octokit;
-using Octokit.Extensions;
 
 namespace DotNet.GitHub
 {

--- a/src/DotNet.GitHub/ModelExtensions.cs
+++ b/src/DotNet.GitHub/ModelExtensions.cs
@@ -76,11 +76,11 @@ namespace DotNet.GitHub
                 var tfms = psr.TargetFrameworkMonikerSupports;
                 document.AppendTable(
                     new MarkdownTableHeader(
-                        new MarkdownTableHeaderCell("TFM in project"),
-                        new MarkdownTableHeaderCell("Target version"),
-                        new MarkdownTableHeaderCell("End of life"),
-                        new MarkdownTableHeaderCell("Release notes"),
-                        new MarkdownTableHeaderCell("Nearest LTS TFM version")),
+                        new("TFM in project"),
+                        new("Target version"),
+                        new("End of life"),
+                        new("Release notes"),
+                        new("Nearest LTS TFM version")),
                     tfms.Where(_ => _.IsUnsupported)
                         .Select(tfm =>
                         {

--- a/src/DotNet.VersionSweeper/Program.cs
+++ b/src/DotNet.VersionSweeper/Program.cs
@@ -49,10 +49,10 @@ static async Task StartSweeperAsync(Options options, IServiceProvider services, 
             IJobService job,
             string title, Options options, Func<Options, string> getBody)
         {
-            var existingIssue =
+            var (isError, existingIssue) =
                 await client.GetIssueAsync(
                     options.Owner, options.Name, options.Token, title);
-            if (existingIssue is null)
+            if (isError)
             {
                 job.Debug($"Error checking for existing issue, best not to create an issue as it may be a duplicate.");
             }

--- a/src/DotNet.VersionSweeper/Program.cs
+++ b/src/DotNet.VersionSweeper/Program.cs
@@ -52,9 +52,13 @@ static async Task StartSweeperAsync(Options options, IServiceProvider services, 
             var existingIssue =
                 await client.GetIssueAsync(
                     options.Owner, options.Name, options.Token, title);
-            if (existingIssue?.State == ItemState.Open)
+            if (existingIssue is null)
             {
-                job.Info($"Re-discovered but ignoring, latent non-LTS version in {existingIssue}.");
+                job.Debug($"Error checking for existing issue, best not to create an issue as it may be a duplicate.");
+            }
+            else if (existingIssue is { State: ItemState.Open })
+            {
+                job.Info($"Re-discovered but ignoring, latent issue: {existingIssue}.");
             }
             else
             {

--- a/test/DotNet.GitHubActionsTests/JobServiceTests.cs
+++ b/test/DotNet.GitHubActionsTests/JobServiceTests.cs
@@ -58,6 +58,18 @@ namespace DotNet.GitHubActionsTests
         {
             new object[]
             {
+                new Dictionary<string, string>
+                {
+                    ["name"] = "summary"
+                },
+                "Everything worked as expected",
+                new[]
+                {
+                    $"::{Commands.SetOutput} name=summary::Everything worked as expected"
+                }
+            },
+            new object[]
+            {
                 null,
                 "deftones",
                 new[]

--- a/test/DotNet.ReleasesTests/DotNet.ReleasesTests.csproj
+++ b/test/DotNet.ReleasesTests/DotNet.ReleasesTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>

--- a/test/DotNet.ReleasesTests/LabeledVersionTests.cs
+++ b/test/DotNet.ReleasesTests/LabeledVersionTests.cs
@@ -16,6 +16,8 @@ namespace DotNet.ReleasesTests
             new object[] { "5.0.2", new LabeledVersion(new Version(5, 0, 2)) },
             new object[] { "3.1.405", new LabeledVersion(new Version(3, 1, 405)) },
             new object[] { "2.2.207", new LabeledVersion(new Version(2, 2, 207)) },
+            new object[] { "8.1.0.314-preview1", new LabeledVersion(new Version(8, 1, 0, 314), "preview1") },
+            new object[] { "7.7.84.34-beta", new LabeledVersion(new Version(7, 7, 84, 34), "beta") },
             new object[] { "3.5.0-sp1", new LabeledVersion(new Version(3, 5, 0), "sp1") },
             new object[] { "pickles", new LabeledVersion(null) }
         };


### PR DESCRIPTION
- Added a check to ensure that the HTTP call to GraphQL was successful
  - Call `response.EnsureSuccessStatusCode()`, this will `throw`
- Update the logic to conditionally create an issue, when, and only when we're able to verify that a dup doesn't already exist
- Minor unit test updates

Fixes: #36