### PR TITLE
Implemented issue grouping by TFM

### DIFF
--- a/src/DotNet.GitHub/DotNet.GitHub.csproj
+++ b/src/DotNet.GitHub/DotNet.GitHub.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Octokit" Version="0.48.0" />
+    <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Octokit.Extensions" Version="1.0.7" />
   </ItemGroup>
 

--- a/src/DotNet.GitHub/ExistingIssue.cs
+++ b/src/DotNet.GitHub/ExistingIssue.cs
@@ -12,6 +12,7 @@ namespace DotNet.GitHub
         public long Number { get; init; }
         public string? Url { get; init; }
         public ItemState State { get; init; }
+        public string? Body { get; init; }
         public DateTime? UpdatedAt { get; init; }
         public DateTime? CreatedAt { get; init; }
         public DateTime? ClosedAt { get; init; }

--- a/src/DotNet.GitHub/GitHubApiArgs.cs
+++ b/src/DotNet.GitHub/GitHubApiArgs.cs
@@ -3,5 +3,9 @@
 
 namespace DotNet.GitHub
 {
-    public record GitHubApiArgs(string Owner, string RepoName, string Token);
+    public record GitHubApiArgs(
+        string Owner,
+        string RepoName,
+        string Token,
+        long IssueNumber = -1);
 }

--- a/src/DotNet.GitHub/GitHubGraphQLClient.cs
+++ b/src/DotNet.GitHub/GitHubGraphQLClient.cs
@@ -23,6 +23,7 @@ namespace DotNet.GitHub
         title
         number
         url
+        body
         state
         createdAt
         updatedAt
@@ -32,7 +33,7 @@ namespace DotNet.GitHub
   }
 }";
 
-        readonly Uri _graphQLUri = new("https://api.github.com/graphql");
+        readonly static Uri s_graphQLUri = new("https://api.github.com/graphql");
         readonly static JsonSerializerOptions s_options = new()
         {
             Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
@@ -67,7 +68,7 @@ namespace DotNet.GitHub
                 request.Headers.ContentType = new(MediaTypeNames.Application.Json);
                 request.Headers.Add("Accepts", MediaTypeNames.Application.Json);
 
-                using var response = await _httpClient.PostAsync(_graphQLUri, request);
+                using var response = await _httpClient.PostAsync(s_graphQLUri, request);
                 response.EnsureSuccessStatusCode();
 
                 var json = await response.Content.ReadAsStringAsync();

--- a/src/DotNet.GitHub/GitHubIssueService.cs
+++ b/src/DotNet.GitHub/GitHubIssueService.cs
@@ -4,7 +4,6 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Octokit;
-using Octokit.Extensions;
 
 namespace DotNet.GitHub
 {
@@ -31,6 +30,22 @@ namespace DotNet.GitHub
             var issue = await issuesClient.Create(owner, name, newIssue);
 
             _logger.LogInformation($"Issue created: {issue.HtmlUrl}");
+
+            return issue;
+        }
+
+        public async ValueTask<Issue> UpdateIssueAsync(
+            string owner, string name, string token, long number, IssueUpdate issueUpdate)
+        {
+            var issuesClient = GetIssuesClient(token);
+
+            // The GitHub GraphQL API returns a long for the issue Id.
+            // The GitHub REST API expects an int for the issue Id.
+
+            var issue = await issuesClient.Update(
+                owner, name, unchecked((int)number), issueUpdate);
+
+            _logger.LogInformation($"Issue updated: {issue.HtmlUrl}");
 
             return issue;
         }

--- a/src/DotNet.GitHub/IGitHubIssueService.cs
+++ b/src/DotNet.GitHub/IGitHubIssueService.cs
@@ -9,6 +9,9 @@ namespace DotNet.GitHub
     public interface IGitHubIssueService
     {
         ValueTask<Issue> PostIssueAsync(
-            string owner, string name, string token, NewIssue issue);
+            string owner, string name, string token, NewIssue newIssue);
+
+        ValueTask<Issue> UpdateIssueAsync(
+            string owner, string name, string token, long number, IssueUpdate issueUpdate);
     }
 }

--- a/src/DotNet.GitHub/ModelExtensions.cs
+++ b/src/DotNet.GitHub/ModelExtensions.cs
@@ -62,7 +62,7 @@ namespace DotNet.GitHub
                         var lineNumberFileReference =
                             $"../blob/{branch}/{relativePath.Replace("\\", "/")}#L{psr.Project.TfmLineNumber}"
                                 .EscapeUriString();
-                        var name = relativePath.FirstAndLastSegmentOfPath("...");
+                        var name = relativePath.ShrinkPath("...");
 
                         return new MarkdownCheckListItem(false, $"[{name}]({lineNumberFileReference})");
                     })));
@@ -115,7 +115,7 @@ namespace DotNet.GitHub
                     Path.GetRelativePath(root, project.FullPath);
 
                 var path = $"../blob/{branch}/{relativePath.Replace("\\", "/")}".EscapeUriString();
-                var name = relativePath.FirstAndLastSegmentOfPath("...");
+                var name = relativePath.ShrinkPath("...");
 
                 return new(false, $"[{name}]({path})");
             }

--- a/src/DotNet.GitHub/ModelExtensions.cs
+++ b/src/DotNet.GitHub/ModelExtensions.cs
@@ -18,162 +18,71 @@ namespace DotNet.GitHub
             this ProjectSupportReport psr) =>
             (Path.GetFileName(psr.Project.FullPath), psr.TargetFrameworkMonikerSupports);
 
-        static (string FileName, int ProjectsTargetingUnsupportedTfms) AsNameSetPair(
-            this SolutionSupportReport psr) =>
-            (Path.GetFileName(psr.Solution.FullPath), psr.ProjectSupportReports.Count(r => r.TargetFrameworkMonikerSupports.Any(t => t.IsUnsupported)));
-
-        public static string ToTitleMessage(
-            this ProjectSupportReport projectSupportReport)
-        {
-            StringBuilder builder = new();
-
-            var (fileName, tfms) = projectSupportReport.AsNameSetPair();
-
-            builder.Append($"Update {fileName} from ");
-            var message =
-                string.Join(
-                    ", ",
-                    tfms.Where(tfm => tfm.IsUnsupported)
-                        .Select(tfm => tfm.Release.ToBrandString()));
-            builder.Append(message);
-            builder.Append(" to LTS (or current) version");
-
-            return builder.ToString();
-        }
-
-        public static string ToTitleMessage(
-            this SolutionSupportReport solutionSupportReport)
-        {
-            var (fileName, cnt) = solutionSupportReport.AsNameSetPair();
-            return $"Update {cnt} projects in {fileName} to LTS (or current) version";
-        }
-
         public static string ToMarkdownBody(
-            this SolutionSupportReport solutionSupportReport,
+            this ISet<ProjectSupportReport> psrs,
+            string tfm,
             string rootDirectory,
             string branch)
         {
             IMarkdownDocument document = new MarkdownDocument();
 
-            var (fileName, cnt) = solutionSupportReport.AsNameSetPair();
-
             document.AppendParagraph(
-                $"There are {cnt} projects in *{fileName}* that target a .NET version which is no longer supported. " +
+                "The following project file(s) target a .NET version which is no longer supported. " +
                 "This is an auto-generated issue, detailed and discussed in [dotnet/docs#22271](https://github.com/dotnet/docs/issues/22271).");
 
-            HashSet<string> relativePaths = new(StringComparer.OrdinalIgnoreCase);
-            foreach (var psr in solutionSupportReport.ProjectSupportReports)
-            {
-                var project = psr.Project;
-                var relativePath =
-                    Path.GetRelativePath(rootDirectory, project.FullPath)
-                        .Replace("\\", "/");
-                relativePaths.Add(relativePath);
-
-                var lineNumberFileReference =
-                    $"../blob/{branch}/{relativePath}#L{project.TfmLineNumber}".EscapeUriString();
-
-                var tfms = psr.TargetFrameworkMonikerSupports;
-                document.AppendTable(
-                    new MarkdownTableHeader(
-                        new("TFM in project"),
-                        new("Target version"),
-                        new("End of life"),
-                        new("Release notes"),
-                        new("Nearest LTS TFM version")),
-                    tfms.Where(_ => _.IsUnsupported)
-                        .Select(tfm =>
-                        {
-                            var (target, version, _, release) = tfm;
-                            return new MarkdownTableRow(
-                                $"[{Path.GetFileName(project.FullPath)}]({lineNumberFileReference})",
-                                $"`{target}`",
-                                release.EndOfLifeDate.HasValue ? $"{release.EndOfLifeDate:MMMM, dd yyyy}" : "N/A",
-                                new MarkdownLink(
-                                    $"{target} release notes", release.ReleaseNotesUrl)
-                                    .ToString(),
-                                $"`{tfm.NearestLtsVersion}`");
-                        }));
-            }
-
-            document.AppendParagraph(
-                "Consider upgrading to either the current release, or the nearest LTS TFM version.");
-
-            document.AppendParagraph(
-                $"If any of these projects are intentionally targeting an unsupported version, " +
-                $"you can optionally configure to ignore this automated issue. " +
-                $"Create a file at the root of the repository, named *dotnet-versionsweeper.json* and " +
-                $"add an `ignore` entry following the " +
-                $"[globbing patterns detailed here](https://docs.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing.matcher#remarks).");
-
-            var total = relativePaths.Count;
-            document.AppendCode("json", @$"{{
-    ""ignore"": [
-{string.Join(Environment.NewLine, relativePaths.Select((relativePath, index) => $"        \"**/{relativePath}\"{(index == total ? "," : "")}"))}
-    ]
-}}");
-
-            return document.ToString();
-        }
-
-        public static string ToMarkdownBody(
-            this ProjectSupportReport psr,
-            string rootDirectory,
-            string branch)
-        {
-            IMarkdownDocument document = new MarkdownDocument();
-
-            var (fileName, tfms) = psr.AsNameSetPair();
-
-            document.AppendParagraph(
-                $"The *{fileName}* project file targets a .NET version which is no longer supported. " +
-                "This is an auto-generated issue, detailed and discussed in [dotnet/docs#22271](https://github.com/dotnet/docs/issues/22271).");
-
-            var relativePath =
-                Path.GetRelativePath(rootDirectory, psr.Project.FullPath)
-                    .Replace("\\", "/");
-
-            var lineNumberFileReference =
-                $"../blob/{branch}/{relativePath}#L{psr.Project.TfmLineNumber}".EscapeUriString();
-
-            document.AppendParagraph(
-                $"See line {psr.Project.TfmLineNumber} in [{relativePath}]({lineNumberFileReference}).");
+            var tfmSupport =
+                psrs.First()
+                    .TargetFrameworkMonikerSupports
+                    .First(tfms => tfms.TargetFrameworkMoniker == tfm);
 
             document.AppendTable(
                 new MarkdownTableHeader(
-                    new MarkdownTableHeaderCell("Target version"),
-                    new MarkdownTableHeaderCell("End of life"),
-                    new MarkdownTableHeaderCell("Release notes"),
-                    new MarkdownTableHeaderCell("Nearest LTS TFM version")),
-                tfms.Where(_ => _.IsUnsupported)
-                    .Select(tfm =>
+                    new("Target version"),
+                    new("End of life"),
+                    new("Release notes"),
+                    new("Nearest LTS TFM version")),
+                new[]
+                {
+                    new MarkdownTableRow(
+                    $"`{tfmSupport.TargetFrameworkMoniker}`",
+                    tfmSupport.Release.EndOfLifeDate.HasValue
+                        ? $"{tfmSupport.Release.EndOfLifeDate:MMMM, dd yyyy}" : "N/A",
+                    new MarkdownLink(
+                        $"{tfmSupport.TargetFrameworkMoniker} release notes", tfmSupport.Release.ReleaseNotesUrl)
+                        .ToString(),
+                    $"`{tfmSupport.NearestLtsVersion}`")
+                });
+
+            document.AppendList(
+                new MarkdownList(
+                    psrs.OrderBy(psr => psr.Project.FullPath).Select(psr =>
                     {
-                        var (target, version, _, release) = tfm;
-                        return new MarkdownTableRow(
-                            $"`{target}`",
-                            release.EndOfLifeDate.HasValue ? $"{release.EndOfLifeDate:MMMM, dd yyyy}" : "N/A",
-                            new MarkdownLink(
-                                $"{target} release notes", release.ReleaseNotesUrl)
-                                .ToString(),
-                            $"`{tfm.NearestLtsVersion}`");
-                    }));
+                        var relativePath =
+                            Path.GetRelativePath(rootDirectory, psr.Project.FullPath);
+
+                        var lineNumberFileReference =
+                            $"../blob/{branch}/{relativePath.Replace("\\", "/")}#L{psr.Project.TfmLineNumber}"
+                                .EscapeUriString();
+                        var name = relativePath.FirstAndLastSegmentOfPath("...");
+
+                        return new MarkdownCheckListItem(false, $"[{name}]({lineNumberFileReference})");
+                    })));
 
             document.AppendParagraph(
-                "Consider upgrading the project to either the current release, or the nearest LTS TFM version.");
+                "Consider upgrading projects to either the current release, or the nearest LTS TFM version.");
 
             document.AppendParagraph(
-                $"If this project is intentionally targeting an unsupported version, " +
-                $"you can optionally configure to ignore this automated issue. " +
+                $"If any of these projects are intentionally targeting an unsupported version, " +
+                $"you can optionally configure to ignore including them in this automated issue. " +
                 $"Create a file at the root of the repository, named *dotnet-versionsweeper.json* and " +
                 $"add an `ignore` entry following the " +
                 $"[globbing patterns detailed here](https://docs.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing.matcher#remarks).");
 
-            document.AppendCode("json", @$"{{
+            document.AppendCode("json", @"{
     ""ignore"": [
-        ""**/{relativePath}""
+        ""**/path/to/example.csproj""
     ]
-}}");
-
+}");
             return document.ToString();
         }
 
@@ -229,7 +138,7 @@ namespace DotNet.GitHub
 
             document.AppendCode("json", @"{
     ""ignore"": [
-        ""**/Path/To/Example.csproj""
+        ""**/path/to/example.csproj""
     ]
 }");
 

--- a/src/DotNet.GitHub/ModelExtensions.cs
+++ b/src/DotNet.GitHub/ModelExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using DotNet.Extensions;
 using DotNet.Models;
 using Markdown;

--- a/test/DotNet.ExtensionsTests/DotNet.ExtensionsTests.csproj
+++ b/test/DotNet.ExtensionsTests/DotNet.ExtensionsTests.csproj
@@ -7,12 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DotNet.ExtensionsTests/StringExtensionsTests.cs
+++ b/test/DotNet.ExtensionsTests/StringExtensionsTests.cs
@@ -12,15 +12,25 @@ namespace DotNet.Extensions.Tests
         public void FirstAndLastSegementsOfPathTest()
         {
             var d = Path.DirectorySeparatorChar;
-            foreach (var (input, expected)
+            foreach (var (input, expected, limit)
                 in new[]
                 {
-                    (null, null),
-                    ($"path-project.csproj", "path-project.csproj"),
-                    ($"example{d}of{d}some{d}path{d}project.csproj", "example/.../project.csproj")
+                    (null, null, 10),
+                    ($"path-project.csproj", "path-project.csproj", 20),
+                    ($"example{d}of{d}some{d}path{d}project.csproj", "example/of/some/path/project.csproj", 40),
+                    (
+                        $"example{d}for{d}some{d}path-to-a{d}project.csproj",
+                        "example/.../some/path-to-a/project.csproj",
+                        40
+                    ),
+                    (
+                        $"dapine{d}source{d}repos{d}dotnet-api-docs{d}samples{d}snippets{d}xaml{d}VS_Snippets_Wpf{d}FrameNavigationUIVisibilitySnippets{d}XAML.csproj",
+                        "dapine/.../dotnet-api-docs/samples/snippets/xaml/VS_Snippets_Wpf/FrameNavigationUIVisibilitySnippets/XAML.csproj",
+                        113
+                    )
                 })
             {
-                Assert.Equal(expected, input.FirstAndLastSegmentOfPath("..."));
+                Assert.Equal(expected, input.ShrinkPath(limit: limit));
             }
         }
     }

--- a/test/DotNet.GitHubActionsTests/DotNet.GitHubActionsTests.csproj
+++ b/test/DotNet.GitHubActionsTests/DotNet.GitHubActionsTests.csproj
@@ -7,12 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DotNet.GitHubTests/DotNet.GitHubTests.csproj
+++ b/test/DotNet.GitHubTests/DotNet.GitHubTests.csproj
@@ -7,14 +7,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.14" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DotNet.IOTests/DotNet.IOTests.csproj
+++ b/test/DotNet.IOTests/DotNet.IOTests.csproj
@@ -7,12 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DotNet.ModelsTests/DotNet.ModelsTests.csproj
+++ b/test/DotNet.ModelsTests/DotNet.ModelsTests.csproj
@@ -7,12 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DotNet.ReleasesTests/DotNet.ReleasesTests.csproj
+++ b/test/DotNet.ReleasesTests/DotNet.ReleasesTests.csproj
@@ -7,12 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DotNet.VersionSweeperTests/DotNet.VersionSweeperTests.csproj
+++ b/test/DotNet.VersionSweeperTests/DotNet.VersionSweeperTests.csproj
@@ -7,12 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Group issue creation by target-framework moniker (TFM). Instead of having ~1,100 new issues in the `dotnet/dotnet-api-docs` repo, with these changes - we'd have only 9 issues, and each issue would contain a checklist for each violation.

- Issues can be updated by the tool
- The markdown for an issue includes a checklist for each violation

Fixes #39