### PR TITLE
Update JsonSerializerOptions to allow trailing commas

### DIFF
--- a/src/DotNet.Extensions/ObjectExtensions.cs
+++ b/src/DotNet.Extensions/ObjectExtensions.cs
@@ -16,7 +16,8 @@ namespace DotNet.Extensions
             Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
             NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString,
-            PropertyNameCaseInsensitive = true
+            PropertyNameCaseInsensitive = true,
+            AllowTrailingCommas = true,
         });
 
         public static string? ToJson(this object value, JsonSerializerOptions? options = default) =>


### PR DESCRIPTION
This allows having trailing commas in *dotnet-versionsweeper.json*, so when *dotnet-versionsweeper.json* is updated with new entries, the diff is cleaner.

---

### Before

A diff would look like:

```diff
{
    "ignore":[
-        "Entry1"
+        "Entry1",
+        "Entry2"
    ]
}
```

---

### After

A diff would look like:

```diff
{
    "ignore":[
        "Entry1",
+       "Entry2",
    ]
}
```