### PR TITLE
Add out of support within days config

### DIFF
--- a/src/DotNet.Releases/Reporting/IUnsupportedProjectReporter.cs
+++ b/src/DotNet.Releases/Reporting/IUnsupportedProjectReporter.cs
@@ -8,6 +8,6 @@ namespace DotNet.Releases
 {
     public interface IUnsupportedProjectReporter
     {
-        IAsyncEnumerable<ProjectSupportReport> ReportAsync(Project project);
+        IAsyncEnumerable<ProjectSupportReport> ReportAsync(Project project, int outOfSupportWithinDays);
     }
 }

--- a/src/DotNet.Reporter/Program.cs
+++ b/src/DotNet.Reporter/Program.cs
@@ -26,7 +26,7 @@ if (args is { Length: 1 })
         if (project is { TfmLineNumber: > -1 })
         {
             var reporter = Get<IUnsupportedProjectReporter>();
-            await foreach (var projectSupportReport in reporter.ReportAsync(project))
+            await foreach (var projectSupportReport in reporter.ReportAsync(project, 0))
             {
                 var (proj, reports) = projectSupportReport;
                 if (reports is { Count: > 0 } && reports.Any(r => r.IsUnsupported))

--- a/src/DotNet.VersionSweeper/ActionType.cs
+++ b/src/DotNet.VersionSweeper/ActionType.cs
@@ -6,7 +6,7 @@ namespace DotNet.VersionSweeper
     public enum ActionType
     {
         CreateIssue,
-        AttemptPullRequest,
+        PullRequest,
         DryRun
     }
 }

--- a/src/DotNet.VersionSweeper/Discovery.cs
+++ b/src/DotNet.VersionSweeper/Discovery.cs
@@ -21,7 +21,7 @@ namespace DotNet.VersionSweeper
         /// Returns a list of solutions, each solution contains projects. Also returns a mapping
         /// of orphaned projects that do not belong to solutions, but match the search patterns.
         /// </summary>
-        internal static async Task<(ISet<Solution> Solutions, ISet<Project> OrphanedProjects)>
+        internal static async Task<(ISet<Solution> Solutions, ISet<Project> OrphanedProjects, VersionSweeperConfig Config)>
             FindSolutionsAndProjectsAsync(
                 IServiceProvider services,
                 IJobService job,
@@ -97,7 +97,8 @@ namespace DotNet.VersionSweeper
             return
                 (
                     Solutions: solutionSet,
-                    OrphanedProjects: orphanedProjectSet
+                    OrphanedProjects: orphanedProjectSet,
+                    Config: config
                 );
         }
     }

--- a/src/DotNet.VersionSweeper/Program.cs
+++ b/src/DotNet.VersionSweeper/Program.cs
@@ -36,7 +36,7 @@ static async Task StartSweeperAsync(Options options, IServiceProvider services, 
     {
         options.WriteDebugInfo(job);
 
-        var (solutions, orphanedProjects) =
+        var (solutions, orphanedProjects, config) =
             await Discovery.FindSolutionsAndProjectsAsync(services, job, options);
 
         var (unsupportedProjectReporter, issueQueue, graphQLClient) =
@@ -117,7 +117,8 @@ static async Task StartSweeperAsync(Options options, IServiceProvider services, 
                     nonSdkStyleProjects.Add(project);
                 }
 
-                await foreach (var psr in unsupportedProjectReporter.ReportAsync(project))
+                await foreach (var psr in unsupportedProjectReporter.ReportAsync(
+                    project, config.OutOfSupportWithinDays))
                 {
                     solutionSupportReport.ProjectSupportReports.Add(psr);
                 }
@@ -145,7 +146,8 @@ static async Task StartSweeperAsync(Options options, IServiceProvider services, 
                 nonSdkStyleProjects.Add(orphanedProject);
             }
 
-            await foreach (var psr in unsupportedProjectReporter.ReportAsync(orphanedProject))
+            await foreach (var psr in unsupportedProjectReporter.ReportAsync(
+                orphanedProject, config.OutOfSupportWithinDays))
             {
                 var (project, reports) = psr;
                 if (reports is { Count: > 0 } && reports.Any(r => r.IsUnsupported))

--- a/src/DotNet.VersionSweeper/VersionSweeperConfig.cs
+++ b/src/DotNet.VersionSweeper/VersionSweeperConfig.cs
@@ -14,6 +14,8 @@ namespace DotNet.VersionSweeper
     /// <summary>
     /// Example 'dotnet-versionsweeper.json' file:
     /// {
+    ///     "type": "pullRequest",
+    ///     "outOfSupportWithinDays": 90,
     ///     "ignore": [
     ///         "**/pinned-versions/**",
     ///         "**/*.fsproj"
@@ -22,10 +24,16 @@ namespace DotNet.VersionSweeper
     /// </summary>
     public class VersionSweeperConfig
     {
-        internal static string FileName = "dotnet-versionsweeper.json";
+        internal const string FileName = "dotnet-versionsweeper.json";
 
         [JsonPropertyName("ignore")]
         public string[] Ignore { get; init; } = Array.Empty<string>();
+
+        [JsonPropertyName("type")]
+        public ActionType Type { get; init; } = ActionType.CreateIssue;
+
+        [JsonPropertyName("outOfSupportWithinDays")]
+        public int OutOfSupportWithinDays { get; init; } = 0;
 
         internal static async Task<VersionSweeperConfig> ReadAsync(string root, IJobService job)
         {
@@ -41,6 +49,8 @@ namespace DotNet.VersionSweeper
 
                     job.Info($"Read {config.Ignore.Length} pattern(s) to ignore:");
                     job.Info($"{string.Join(",", config.Ignore.Select(val => $"\t{val}"))}");
+                    job.Info($"Intended version sweeper type: {config.Type}");
+                    job.Info($"Out of support within days: {config.OutOfSupportWithinDays}");
 
                     return config;
                 }


### PR DESCRIPTION
Added a config value that will allow us to specify the number of additional days to consider flagging versions that will be out of support. For example:

```json
{
  "outOfSupportWithinDays": 90,
  "ignore": [
    "**/pinned-versions/**",
    "**/*.fsproj"
  ]
}
```

This will flag all out of support versions, but also versions that will be out of support 90 days from now.