### PR TITLE
Upgrade the version sweeper to .NET 6 and C# 10

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -162,6 +162,9 @@ dotnet_code_quality.ca1802.api_surface = private, internal
 dotnet_code_quality.ca1822.api_surface = private, internal
 dotnet_code_quality.ca2208.api_surface = public
 
+# Namespace preference
+csharp_style_namespace_declarations = file_scoped:warning
+
 # License header
 file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ on:
     - '**.sln'
 
 env:
-  DOTNET_VERSION: '5.0.102' # SDK version
+  DOTNET_VERSION: '6.0.x' # SDK version
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,10 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false
@@ -47,21 +51,24 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+    - name: Setup .NET 6.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - name: Install dependencies
+      run: dotnet restore
+      
+    - name: Build
+      run: |
+        dotnet build ./src/DotNet.Extensions/DotNet.Extensions.csproj --configuration Release
+        dotnet build ./src/DotNet.GitHub/DotNet.GitHub.csproj --configuration Release
+        dotnet build ./src/DotNet.GitHubActions/DotNet.GitHubActions.csproj --configuration Release
+        dotnet build ./src/DotNet.IO/DotNet.IO.csproj --configuration Release
+        dotnet build ./src/DotNet.Models/DotNet.Models.csproj --configuration Release
+        dotnet build ./src/DotNet.Releases/DotNet.Releases.csproj --configuration Release
+        dotnet build ./src/DotNet.Reporter/DotNet.Reporter.csproj --configuration Release
+        dotnet build ./src/DotNet.VersionSweeper/DotNet.VersionSweeper.csproj --configuration Release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+﻿FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 
 # Copy everything and restore
 COPY . ./
@@ -15,6 +15,6 @@ LABEL com.github.actions.icon="alert-circle"
 LABEL com.github.actions.color="yellow"
 
 # Build the runtime image
-FROM mcr.microsoft.com/dotnet/runtime:5.0
+FROM mcr.microsoft.com/dotnet/runtime:6.0
 COPY --from=build-env /out .
 ENTRYPOINT [ "dotnet", "/DotNet.VersionSweeper.dll" ]

--- a/dotnet-versionsweeper.sln
+++ b/dotnet-versionsweeper.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30803.129
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32002.185
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNet.VersionSweeper", "src\DotNet.VersionSweeper\DotNet.VersionSweeper.csproj", "{835DBC44-B11C-45E8-A042-D550FC96F4B0}"
 EndProject
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		action.yml = action.yml
 		.github\workflows\build-and-test.yml = .github\workflows\build-and-test.yml
 		CODE-OF-CONDUCT.md = CODE-OF-CONDUCT.md
+		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 		Dockerfile = Dockerfile
 		.github\workflows\dog-food.yml = .github\workflows\dog-food.yml
 		dotnet-versionsweeper.json = dotnet-versionsweeper.json
@@ -64,7 +65,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNet.IO", "src\DotNet.IO\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNet.IOTests", "test\DotNet.IOTests\DotNet.IOTests.csproj", "{B401F1C9-3212-490D-979A-E35B510FBDE9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNet.GitHubActionsTests", "test\DotNet.GitHubActionsTests\DotNet.GitHubActionsTests.csproj", "{D41F19E7-3FC5-4E41-8F46-9ADA2B7D6EAF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNet.GitHubActionsTests", "test\DotNet.GitHubActionsTests\DotNet.GitHubActionsTests.csproj", "{D41F19E7-3FC5-4E41-8F46-9ADA2B7D6EAF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/DotNet.Extensions/DictionaryExtensions.cs
+++ b/src/DotNet.Extensions/DictionaryExtensions.cs
@@ -1,61 +1,54 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+namespace DotNet.Extensions;
 
-namespace DotNet.Extensions
+/// <summary>
+/// Inspired by: https://stackoverflow.com/a/66193734/2410379
+/// </summary>
+public static class DictionaryExtensions
 {
-    /// <summary>
-    /// Inspired by: https://stackoverflow.com/a/66193734/2410379
-    /// </summary>
-    public static class DictionaryExtensions
+    class ReadOnlyDictionaryWrapper<TKey, TValue>
+        : IReadOnlyDictionary<TKey, TValue>
+        where TKey : notnull
     {
-        class ReadOnlyDictionaryWrapper<TKey, TValue>
-            : IReadOnlyDictionary<TKey, TValue>
-            where TKey : notnull
+        private readonly IDictionary<TKey, TValue> _dictionary;
+
+        public ReadOnlyDictionaryWrapper(IDictionary<TKey, TValue> dictionary) =>
+            _dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+
+        public bool ContainsKey(TKey key) => _dictionary.ContainsKey(key);
+
+        public IEnumerable<TKey> Keys => _dictionary.Keys;
+
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
         {
-            private readonly IDictionary<TKey, TValue> _dictionary;
-
-            public ReadOnlyDictionaryWrapper(IDictionary<TKey, TValue> dictionary) =>
-                _dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
-
-            public bool ContainsKey(TKey key) => _dictionary.ContainsKey(key);
-
-            public IEnumerable<TKey> Keys => _dictionary.Keys;
-
-            public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
-            {
-                var result = _dictionary.TryGetValue(key, out var tempValue);
-                value = tempValue!;
-                return result;
-            }
-
-            public IEnumerable<TValue> Values => _dictionary.Values.Cast<TValue>();
-
-            public TValue this[TKey key] => _dictionary[key];
-
-            public int Count => _dictionary.Count;
-
-            public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() =>
-                _dictionary.Select(x => new KeyValuePair<TKey, TValue>(x.Key, x.Value)).GetEnumerator();
-
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            var result = _dictionary.TryGetValue(key, out var tempValue);
+            value = tempValue!;
+            return result;
         }
 
-        /// <summary>
-        /// Creates a wrapper on a dictionary that adapts the type of the values.
-        /// </summary>
-        /// <typeparam name="TKey">The dictionary key.</typeparam>
-        /// <typeparam name="TValue">The dictionary value.</typeparam>
-        /// <param name="source">The source dictionary.</param>
-        /// <returns>A dictionary where values are a base type of this dictionary.</returns>
-        public static IReadOnlyDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(
-            this IDictionary<TKey, TValue> source)
-            where TKey : notnull =>
-            new ReadOnlyDictionaryWrapper<TKey, TValue>(source);
+        public IEnumerable<TValue> Values => _dictionary.Values.Cast<TValue>();
+
+        public TValue this[TKey key] => _dictionary[key];
+
+        public int Count => _dictionary.Count;
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() =>
+            _dictionary.Select(x => new KeyValuePair<TKey, TValue>(x.Key, x.Value)).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
+
+    /// <summary>
+    /// Creates a wrapper on a dictionary that adapts the type of the values.
+    /// </summary>
+    /// <typeparam name="TKey">The dictionary key.</typeparam>
+    /// <typeparam name="TValue">The dictionary value.</typeparam>
+    /// <param name="source">The source dictionary.</param>
+    /// <returns>A dictionary where values are a base type of this dictionary.</returns>
+    public static IReadOnlyDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(
+        this IDictionary<TKey, TValue> source)
+        where TKey : notnull =>
+        new ReadOnlyDictionaryWrapper<TKey, TValue>(source);
 }

--- a/src/DotNet.Extensions/DotNet.Extensions.csproj
+++ b/src/DotNet.Extensions/DotNet.Extensions.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   

--- a/src/DotNet.Extensions/DotNet.Extensions.csproj
+++ b/src/DotNet.Extensions/DotNet.Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   

--- a/src/DotNet.Extensions/EnumerableExtensions.cs
+++ b/src/DotNet.Extensions/EnumerableExtensions.cs
@@ -1,40 +1,35 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
-namespace DotNet.Extensions
+namespace DotNet.Extensions;
+
+// https://blogs.msdn.microsoft.com/pfxteam/2012/03/05/implementing-a-simple-foreachasync-part-2/
+public static class EnumerableExtensions
 {
-    // https://blogs.msdn.microsoft.com/pfxteam/2012/03/05/implementing-a-simple-foreachasync-part-2/
-    public static class EnumerableExtensions
-    {
-        public static Task ForEachAsync<T>(this IEnumerable<T> source, int dop, Func<T, Task> body) =>
-            Task.WhenAll(
-                from partition in Partitioner.Create(source).GetPartitions(dop)
-                select Task.Run(async delegate
+    public static Task ForEachAsync<T>(this IEnumerable<T> source, int dop, Func<T, Task> body) =>
+        Task.WhenAll(
+            from partition in Partitioner.Create(source).GetPartitions(dop)
+            select Task.Run(async delegate
+            {
+                using (partition)
                 {
-                    using (partition)
+                    while (partition.MoveNext())
                     {
-                        while (partition.MoveNext())
-                        {
-                            await body(partition.Current);
-                        }
+                        await body(partition.Current);
                     }
-                }));
+                }
+            }));
 
-        public static void ForEach<T>(this IEnumerable<T> source, Action<T> action)
-        {
-            if (action is null) return;
-            foreach (var item in source) action(item);
-        }
-
-        public static Dictionary<string, string> AsReverseMap(
-            this Dictionary<string, string> dictionary) =>
-            dictionary.Concat(dictionary.ToDictionary(kvp => kvp.Value, kvp => kvp.Key))
-                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+    public static void ForEach<T>(this IEnumerable<T> source, Action<T> action)
+    {
+        if (action is null) return;
+        foreach (var item in source) action(item);
     }
+
+    public static Dictionary<string, string> AsReverseMap(
+        this Dictionary<string, string> dictionary) =>
+        dictionary.Concat(dictionary.ToDictionary(kvp => kvp.Value, kvp => kvp.Key))
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 }

--- a/src/DotNet.Extensions/EnumerableExtensions.cs
+++ b/src/DotNet.Extensions/EnumerableExtensions.cs
@@ -36,20 +36,5 @@ namespace DotNet.Extensions
             this Dictionary<string, string> dictionary) =>
             dictionary.Concat(dictionary.ToDictionary(kvp => kvp.Value, kvp => kvp.Key))
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-
-        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(
-            this IEnumerable<TSource> source,
-            Func<TSource, TKey> keySelector,
-            IEqualityComparer<TKey>? equalityComparer = default)
-        {
-            HashSet<TKey> keys = new(equalityComparer ?? EqualityComparer<TKey>.Default);
-            foreach (var element in source)
-            {
-                if (keys.Add(keySelector(element)))
-                {
-                    yield return element;
-                }
-            }
-        }
     }
 }

--- a/src/DotNet.Extensions/GlobalUsings.cs
+++ b/src/DotNet.Extensions/GlobalUsings.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+global using System;
+global using System.Collections;
+global using System.Collections.Generic;
+global using System.Diagnostics.CodeAnalysis;
+global using System.Linq;
+global using System.Text;
+global using System.Text.Encodings.Web;
+global using System.Text.Json;
+global using System.Text.Json.Serialization;
+global using System.Threading.Tasks;
+global using static System.Text.Json.JsonSerializer;

--- a/src/DotNet.Extensions/ObjectExtensions.cs
+++ b/src/DotNet.Extensions/ObjectExtensions.cs
@@ -1,36 +1,29 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Text.Encodings.Web;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using static System.Text.Json.JsonSerializer;
+namespace DotNet.Extensions;
 
-namespace DotNet.Extensions
+public static class ObjectExtensions
 {
-    public static class ObjectExtensions
+    static readonly Lazy<JsonSerializerOptions> _lazyOptions = new(() => new()
     {
-        static readonly Lazy<JsonSerializerOptions> _lazyOptions = new(() => new()
-        {
-            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-            NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString,
-            PropertyNameCaseInsensitive = true,
-            AllowTrailingCommas = true,
-        });
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString,
+        PropertyNameCaseInsensitive = true,
+        AllowTrailingCommas = true,
+    });
 
-        public static string? ToJson(this object value, JsonSerializerOptions? options = default) =>
-            value is null ? null : Serialize(value, options ?? _lazyOptions.Value);
+    public static string? ToJson(this object value, JsonSerializerOptions? options = default) =>
+        value is null ? null : Serialize(value, options ?? _lazyOptions.Value);
 
-        public static T? FromJson<T>(this string? json, JsonSerializerOptions? options = default) =>
-            string.IsNullOrWhiteSpace(json) ? default : Deserialize<T>(json, options ?? _lazyOptions.Value);
+    public static T? FromJson<T>(this string? json, JsonSerializerOptions? options = default) =>
+        string.IsNullOrWhiteSpace(json) ? default : Deserialize<T>(json, options ?? _lazyOptions.Value);
 
-        public static DateTime? ToDateTime(this string? value) =>
-            value is null ? default : DateTime.TryParse(value, out var dateTime) ? dateTime : null;
+    public static DateTime? ToDateTime(this string? value) =>
+        value is null ? default : DateTime.TryParse(value, out var dateTime) ? dateTime : null;
 
-        public static void Deconstruct<T>(
-            this T? nullable, out bool hasValue, out T value) where T : struct =>
-            (hasValue, value) = (nullable.HasValue, nullable.GetValueOrDefault());
-    }
+    public static void Deconstruct<T>(
+        this T? nullable, out bool hasValue, out T value) where T : struct =>
+        (hasValue, value) = (nullable.HasValue, nullable.GetValueOrDefault());
 }

--- a/src/DotNet.Extensions/StringExtensions.cs
+++ b/src/DotNet.Extensions/StringExtensions.cs
@@ -14,7 +14,7 @@ namespace DotNet.Extensions
             string.IsNullOrWhiteSpace(value) ? null : value;
 
         public static string EscapeUriString(this string? value) =>
-            Uri.EscapeUriString(value ?? "");
+            Uri.EscapeDataString(value ?? "");
 
         // Inspired and adapted from: https://stackoverflow.com/a/51282271/2410379
         public static string? ShrinkPath(

--- a/src/DotNet.Extensions/StringExtensions.cs
+++ b/src/DotNet.Extensions/StringExtensions.cs
@@ -1,60 +1,54 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+namespace DotNet.Extensions;
 
-namespace DotNet.Extensions
+public static class StringExtensions
 {
-    public static class StringExtensions
+    public static string? NullIfEmpty(this string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+
+    public static string EscapeUriString(this string? value) =>
+        Uri.EscapeDataString(value ?? "");
+
+    // Inspired and adapted from: https://stackoverflow.com/a/51282271/2410379
+    public static string? ShrinkPath(
+        this string value, string spacer = "...", int limit = 125)
     {
-        public static string? NullIfEmpty(this string? value) =>
-            string.IsNullOrWhiteSpace(value) ? null : value;
-
-        public static string EscapeUriString(this string? value) =>
-            Uri.EscapeDataString(value ?? "");
-
-        // Inspired and adapted from: https://stackoverflow.com/a/51282271/2410379
-        public static string? ShrinkPath(
-            this string value, string spacer = "...", int limit = 125)
+        if (string.IsNullOrWhiteSpace(value))
         {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                return null;
-            }
-            if (value.Length <= limit)
-            {
-                return value.Replace('\\', '/');
-            }
+            return null;
+        }
+        if (value.Length <= limit)
+        {
+            return value.Replace('\\', '/');
+        }
 
-            var file = new FileInfo(value);
-            var segments = value.Split(Path.DirectorySeparatorChar);
-            var parts = new List<string>
+        var file = new FileInfo(value);
+        var segments = value.Split(Path.DirectorySeparatorChar);
+        var parts = new List<string>
             {
                 segments[0],
                 spacer,
                 segments[^1]
             };
 
-            StringBuilder result = new(string.Join('/', parts));
+        StringBuilder result = new(string.Join('/', parts));
 
-            var dir = file.Directory;
-            while (result.Length < limit && dir is not null)
+        var dir = file.Directory;
+        while (result.Length < limit && dir is not null)
+        {
+            if (result.Length + dir.Name.Length > limit)
             {
-                if (result.Length + dir.Name.Length > limit)
-                {
-                    break;
-                }
-
-                parts.Insert(2, dir.Name);
-
-                dir = dir.Parent;
-                result = new(string.Join('/', parts));
+                break;
             }
 
-            return result.ToString();
+            parts.Insert(2, dir.Name);
+
+            dir = dir.Parent;
+            result = new(string.Join('/', parts));
         }
+
+        return result.ToString();
     }
 }

--- a/src/DotNet.GitHub/DefaultLabel.cs
+++ b/src/DotNet.GitHub/DefaultLabel.cs
@@ -1,20 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Octokit;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+class DefaultLabel
 {
-    class DefaultLabel
-    {
-        internal const string Name = "dotnet-target-version";
-        internal const string Color = "512bd4";
-        internal const string Description =
-            "Issues and PRs automatically generated from the .NET version sweeper.";
+    internal const string Name = "dotnet-target-version";
+    internal const string Color = "512bd4";
+    internal const string Description =
+        "Issues and PRs automatically generated from the .NET version sweeper.";
 
-        internal static NewLabel Value { get; } = new(Name, Color)
-        {
-            Description = Description
-        };
-    }
+    internal static NewLabel Value { get; } = new(Name, Color)
+    {
+        Description = Description
+    };
 }

--- a/src/DotNet.GitHub/DefaultResilientGitHubClientFactory.cs
+++ b/src/DotNet.GitHub/DefaultResilientGitHubClientFactory.cs
@@ -1,22 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Octokit;
-using Octokit.Extensions;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public class DefaultResilientGitHubClientFactory : IResilientGitHubClientFactory
 {
-    public class DefaultResilientGitHubClientFactory : IResilientGitHubClientFactory
-    {
-        readonly ResilientGitHubClientFactory _clientFactory;
+    readonly ResilientGitHubClientFactory _clientFactory;
 
-        public DefaultResilientGitHubClientFactory(
-            ResilientGitHubClientFactory clientFactory) =>
-            _clientFactory = clientFactory;
+    public DefaultResilientGitHubClientFactory(
+        ResilientGitHubClientFactory clientFactory) =>
+        _clientFactory = clientFactory;
 
-        public IGitHubClient Create(string token) =>
-            _clientFactory.Create(
-                productHeaderValue: GitHubProduct.Header,
-                credentials: new(token));
-    }
+    public IGitHubClient Create(string token) =>
+        _clientFactory.Create(
+            productHeaderValue: GitHubProduct.Header,
+            credentials: new(token));
 }

--- a/src/DotNet.GitHub/DotNet.GitHub.csproj
+++ b/src/DotNet.GitHub/DotNet.GitHub.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/DotNet.GitHub/DotNet.GitHub.csproj
+++ b/src/DotNet.GitHub/DotNet.GitHub.csproj
@@ -1,15 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MarkdownBuilder" Version="0.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Octokit.Extensions" Version="1.0.7" />
   </ItemGroup>

--- a/src/DotNet.GitHub/ExistingIssue.cs
+++ b/src/DotNet.GitHub/ExistingIssue.cs
@@ -1,20 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Octokit;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public record ExistingIssue
 {
-    public record ExistingIssue
-    {
-        public string? Title { get; init; }
-        public long Number { get; init; }
-        public string? Url { get; init; }
-        public ItemState State { get; init; }
-        public string? Body { get; init; }
-        public DateTime? UpdatedAt { get; init; }
-        public DateTime? CreatedAt { get; init; }
-        public DateTime? ClosedAt { get; init; }
-    }
+    public string? Title { get; init; }
+    public long Number { get; init; }
+    public string? Url { get; init; }
+    public ItemState State { get; init; }
+    public string? Body { get; init; }
+    public DateTime? UpdatedAt { get; init; }
+    public DateTime? CreatedAt { get; init; }
+    public DateTime? ClosedAt { get; init; }
 }

--- a/src/DotNet.GitHub/GitHubApiArgs.cs
+++ b/src/DotNet.GitHub/GitHubApiArgs.cs
@@ -1,11 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DotNet.GitHub
-{
-    public record GitHubApiArgs(
-        string Owner,
-        string RepoName,
-        string Token,
-        long IssueNumber = -1);
-}
+namespace DotNet.GitHub;
+
+public record GitHubApiArgs(
+    string Owner,
+    string RepoName,
+    string Token,
+    long IssueNumber = -1);

--- a/src/DotNet.GitHub/GitHubGraphQLClient.cs
+++ b/src/DotNet.GitHub/GitHubGraphQLClient.cs
@@ -1,22 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Linq;
-using System.Net.Http;
-using System.Net.Mime;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
-using DotNet.Extensions;
-using Microsoft.Extensions.Logging;
-using Octokit;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public class GitHubGraphQLClient
 {
-    public class GitHubGraphQLClient
-    {
-        const string _issueQuery = @"query($search_value: String!) {
+    const string _issueQuery = @"query($search_value: String!) {
   search(type: ISSUE, query: $search_value, first: 10) {
     nodes {
       ... on Issue {
@@ -33,58 +22,57 @@ namespace DotNet.GitHub
   }
 }";
 
-        readonly static Uri s_graphQLUri = new("https://api.github.com/graphql");
-        readonly static JsonSerializerOptions s_options = new()
+    readonly static Uri s_graphQLUri = new("https://api.github.com/graphql");
+    readonly static JsonSerializerOptions s_options = new()
+    {
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        PropertyNameCaseInsensitive = true
+    };
+
+    readonly HttpClient _httpClient;
+    readonly ILogger<GitHubGraphQLClient> _logger;
+
+    public GitHubGraphQLClient(HttpClient httpClient, ILogger<GitHubGraphQLClient> logger) =>
+        (_httpClient, _logger) = (httpClient, logger);
+
+    public async Task<(bool IsError, ExistingIssue? Issue)> GetIssueAsync(
+        string owner, string name, string token, string title)
+    {
+        try
         {
-            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
-            PropertyNameCaseInsensitive = true
-        };
+            _httpClient.DefaultRequestHeaders.Authorization = new("Token", token);
+            _httpClient.DefaultRequestHeaders.UserAgent.Add(
+                new(GitHubProduct.Header.Name, GitHubProduct.Header.Version));
 
-        readonly HttpClient _httpClient;
-        readonly ILogger<GitHubGraphQLClient> _logger;
-
-        public GitHubGraphQLClient(HttpClient httpClient, ILogger<GitHubGraphQLClient> logger) =>
-            (_httpClient, _logger) = (httpClient, logger);
-
-        public async Task<(bool IsError, ExistingIssue? Issue)> GetIssueAsync(
-            string owner, string name, string token, string title)
-        {
-            try
+            GraphQLRequest graphQLRequest = new()
             {
-                _httpClient.DefaultRequestHeaders.Authorization = new("Token", token);
-                _httpClient.DefaultRequestHeaders.UserAgent.Add(
-                    new(GitHubProduct.Header.Name, GitHubProduct.Header.Version));
-
-                GraphQLRequest graphQLRequest = new()
-                {
-                    Query = _issueQuery,
-                    Variables =
+                Query = _issueQuery,
+                Variables =
                     {
                         ["search_value"] = $"repo:{owner}/{name} type:issue '{title}' in:title"
                     }
-                };
+            };
 
-                using var request = new StringContent(graphQLRequest.ToString());
-                request.Headers.ContentType = new(MediaTypeNames.Application.Json);
-                request.Headers.Add("Accepts", MediaTypeNames.Application.Json);
+            using var request = new StringContent(graphQLRequest.ToString());
+            request.Headers.ContentType = new(MediaTypeNames.Application.Json);
+            request.Headers.Add("Accepts", MediaTypeNames.Application.Json);
 
-                using var response = await _httpClient.PostAsync(s_graphQLUri, request);
-                response.EnsureSuccessStatusCode();
+            using var response = await _httpClient.PostAsync(s_graphQLUri, request);
+            response.EnsureSuccessStatusCode();
 
-                var json = await response.Content.ReadAsStringAsync();
-                var result = json.FromJson<GraphQLResult<ExistingIssue>>(s_options);
+            var json = await response.Content.ReadAsStringAsync();
+            var result = json.FromJson<GraphQLResult<ExistingIssue>>(s_options);
 
-                return (false, result?.Data?.Search?.Nodes
-                    ?.Where(i => i.State == ItemState.Open)
-                    ?.OrderByDescending(i => i.CreatedAt.GetValueOrDefault())
-                    ?.FirstOrDefault());
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, ex.Message);
+            return (false, result?.Data?.Search?.Nodes
+                ?.Where(i => i.State == ItemState.Open)
+                ?.OrderByDescending(i => i.CreatedAt.GetValueOrDefault())
+                ?.FirstOrDefault());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, ex.Message);
 
-                return (true, default);
-            }
+            return (true, default);
         }
     }
 }

--- a/src/DotNet.GitHub/GitHubIssueService.cs
+++ b/src/DotNet.GitHub/GitHubIssueService.cs
@@ -1,59 +1,54 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Octokit;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public class GitHubIssueService : IGitHubIssueService
 {
-    public class GitHubIssueService : IGitHubIssueService
+    readonly IResilientGitHubClientFactory _clientFactory;
+    readonly IGitHubLabelService _gitHubLabelService;
+    readonly ILogger<GitHubIssueService> _logger;
+
+    public GitHubIssueService(
+        IResilientGitHubClientFactory clientFactory,
+        IGitHubLabelService gitHubLabelService,
+        ILogger<GitHubIssueService> logger) =>
+        (_clientFactory, _gitHubLabelService, _logger) = (clientFactory, gitHubLabelService, logger);
+
+    public async ValueTask<Issue> PostIssueAsync(
+        string owner, string name, string token, NewIssue newIssue)
     {
-        readonly IResilientGitHubClientFactory _clientFactory;
-        readonly IGitHubLabelService _gitHubLabelService;
-        readonly ILogger<GitHubIssueService> _logger;
+        var issuesClient = GetIssuesClient(token);
 
-        public GitHubIssueService(
-            IResilientGitHubClientFactory clientFactory,
-            IGitHubLabelService gitHubLabelService,
-            ILogger<GitHubIssueService> logger) =>
-            (_clientFactory, _gitHubLabelService, _logger) = (clientFactory, gitHubLabelService, logger);
+        var label = await _gitHubLabelService.GetOrCreateLabelAsync(owner, name, token);
+        newIssue.Labels.Add(label.Name);
 
-        public async ValueTask<Issue> PostIssueAsync(
-            string owner, string name, string token, NewIssue newIssue)
-        {
-            var issuesClient = GetIssuesClient(token);
+        var issue = await issuesClient.Create(owner, name, newIssue);
 
-            var label = await _gitHubLabelService.GetOrCreateLabelAsync(owner, name, token);
-            newIssue.Labels.Add(label.Name);
+        _logger.LogInformation($"Issue created: {issue.HtmlUrl}");
 
-            var issue = await issuesClient.Create(owner, name, newIssue);
+        return issue;
+    }
 
-            _logger.LogInformation($"Issue created: {issue.HtmlUrl}");
+    public async ValueTask<Issue> UpdateIssueAsync(
+        string owner, string name, string token, long number, IssueUpdate issueUpdate)
+    {
+        var issuesClient = GetIssuesClient(token);
 
-            return issue;
-        }
+        // The GitHub GraphQL API returns a long for the issue Id.
+        // The GitHub REST API expects an int for the issue Id.
 
-        public async ValueTask<Issue> UpdateIssueAsync(
-            string owner, string name, string token, long number, IssueUpdate issueUpdate)
-        {
-            var issuesClient = GetIssuesClient(token);
+        var issue = await issuesClient.Update(
+            owner, name, unchecked((int)number), issueUpdate);
 
-            // The GitHub GraphQL API returns a long for the issue Id.
-            // The GitHub REST API expects an int for the issue Id.
+        _logger.LogInformation($"Issue updated: {issue.HtmlUrl}");
 
-            var issue = await issuesClient.Update(
-                owner, name, unchecked((int)number), issueUpdate);
+        return issue;
+    }
 
-            _logger.LogInformation($"Issue updated: {issue.HtmlUrl}");
-
-            return issue;
-        }
-
-        IIssuesClient GetIssuesClient(string token)
-        {
-            var client = _clientFactory.Create(token);
-            return client.Issue;
-        }
+    IIssuesClient GetIssuesClient(string token)
+    {
+        var client = _clientFactory.Create(token);
+        return client.Issue;
     }
 }

--- a/src/DotNet.GitHub/GitHubLabelService.cs
+++ b/src/DotNet.GitHub/GitHubLabelService.cs
@@ -1,77 +1,68 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Logging;
-using Octokit;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public sealed class GitHubLabelService : IGitHubLabelService, IDisposable
 {
-    public sealed class GitHubLabelService : IGitHubLabelService, IDisposable
+    readonly IResilientGitHubClientFactory _clientFactory;
+    readonly ILogger<GitHubLabelService> _logger;
+    readonly IMemoryCache _cache;
+
+    private readonly SemaphoreSlim _labelCreationSemaphore = new(1, 1);
+    private Label _label = null!;
+
+    public GitHubLabelService(
+        IResilientGitHubClientFactory clientFactory,
+        ILogger<GitHubLabelService> logger,
+        IMemoryCache cache) =>
+        (_clientFactory, _logger, _cache) = (clientFactory, logger, cache);
+
+    public async ValueTask<Label> GetOrCreateLabelAsync(
+        string owner, string name, string token)
     {
-        readonly IResilientGitHubClientFactory _clientFactory;
-        readonly ILogger<GitHubLabelService> _logger;
-        readonly IMemoryCache _cache;
+        var labelsClient = GetLabelsClient(token);
+        var cacheKey = $"{owner}/{name}/labels";
+        var labels = await _cache.GetOrCreateAsync(
+            cacheKey,
+            async _ => await labelsClient.GetAllForRepository(owner, name));
 
-        private readonly SemaphoreSlim _labelCreationSemaphore = new(1, 1);
-        private Label _label = null!;
-
-        public GitHubLabelService(
-            IResilientGitHubClientFactory clientFactory,
-            ILogger<GitHubLabelService> logger,
-            IMemoryCache cache) =>
-            (_clientFactory, _logger, _cache) = (clientFactory, logger, cache);
-
-        public async ValueTask<Label> GetOrCreateLabelAsync(
-            string owner, string name, string token)
+        var label = labels?.FirstOrDefault(l => l.Name == DefaultLabel.Name);
+        if (label is not null)
         {
-            var labelsClient = GetLabelsClient(token);
-            var cacheKey = $"{owner}/{name}/labels";
-            var labels = await _cache.GetOrCreateAsync(
-                cacheKey,
-                async _ => await labelsClient.GetAllForRepository(owner, name));
-
-            var label = labels?.FirstOrDefault(l => l.Name == DefaultLabel.Name);
-            if (label is not null)
+            return _label = label;
+        }
+        else
+        {
+            await _labelCreationSemaphore.WaitAsync();
+            try
             {
-                return _label = label;
+                if (_label is null)
+                {
+                    _logger.LogInformation($"Creating '{DefaultLabel.Name}' label.");
+                    _label = await CreateLabelAsync(labelsClient, owner, name);
+                    _cache.Remove(cacheKey);
+                }
+
+                return _label;
             }
-            else
+            finally
             {
-                await _labelCreationSemaphore.WaitAsync();
-                try
-                {
-                    if (_label is null)
-                    {
-                        _logger.LogInformation($"Creating '{DefaultLabel.Name}' label.");
-                        _label = await CreateLabelAsync(labelsClient, owner, name);
-                        _cache.Remove(cacheKey);
-                    }
-
-                    return _label;
-                }
-                finally
-                {
-                    _labelCreationSemaphore.Release();
-                }
+                _labelCreationSemaphore.Release();
             }
         }
-
-        IIssuesLabelsClient GetLabelsClient(string token)
-        {
-            var client = _clientFactory.Create(token);
-            var labelsClient = client.Issue.Labels;
-            return labelsClient;
-        }
-
-        static Task<Label> CreateLabelAsync(
-            IIssuesLabelsClient labelsClient, string owner, string name) =>
-            labelsClient.Create(owner, name, DefaultLabel.Value);
-
-        public void Dispose() => _labelCreationSemaphore.Dispose();
     }
+
+    IIssuesLabelsClient GetLabelsClient(string token)
+    {
+        var client = _clientFactory.Create(token);
+        var labelsClient = client.Issue.Labels;
+        return labelsClient;
+    }
+
+    static Task<Label> CreateLabelAsync(
+        IIssuesLabelsClient labelsClient, string owner, string name) =>
+        labelsClient.Create(owner, name, DefaultLabel.Value);
+
+    public void Dispose() => _labelCreationSemaphore.Dispose();
 }

--- a/src/DotNet.GitHub/GitHubProduct.cs
+++ b/src/DotNet.GitHub/GitHubProduct.cs
@@ -1,15 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Octokit;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public static class GitHubProduct
 {
-    public static class GitHubProduct
-    {
-        static readonly string _name = "DotNetVersionSweeper";
-        static readonly string _version = "1.0";
+    static readonly string _name = "DotNetVersionSweeper";
+    static readonly string _version = "1.0";
 
-        public static ProductHeaderValue Header { get; } = new(_name, _version);
-    }
+    public static ProductHeaderValue Header { get; } = new(_name, _version);
 }

--- a/src/DotNet.GitHub/GlobalUsings.cs
+++ b/src/DotNet.GitHub/GlobalUsings.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+global using System.Collections.Concurrent;
+global using System.Net.Mime;
+global using System.Text.Json;
+global using System.Text.Json.Serialization;
+global using DotNet.Extensions;
+global using DotNet.Models;
+global using Markdown;
+global using Microsoft.Extensions.Caching.Memory;
+global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.Logging;
+global using Octokit;
+global using Octokit.Extensions;
+global using ModelProject = DotNet.Models.Project;

--- a/src/DotNet.GitHub/GraphQLRequest.cs
+++ b/src/DotNet.GitHub/GraphQLRequest.cs
@@ -1,20 +1,15 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-using DotNet.Extensions;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public record GraphQLRequest
 {
-    public record GraphQLRequest
-    {
-        [JsonPropertyName("query")]
-        public string Query { get; init; } = "";
+    [JsonPropertyName("query")]
+    public string Query { get; init; } = "";
 
-        [JsonPropertyName("variables")]
-        public Dictionary<string, string> Variables { get; init; } = new();
+    [JsonPropertyName("variables")]
+    public Dictionary<string, string> Variables { get; init; } = new();
 
-        public override string ToString() => this.ToJson()!;
-    }
+    public override string ToString() => this.ToJson()!;
 }

--- a/src/DotNet.GitHub/IGitHubIssueService.cs
+++ b/src/DotNet.GitHub/IGitHubIssueService.cs
@@ -1,17 +1,13 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading.Tasks;
-using Octokit;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public interface IGitHubIssueService
 {
-    public interface IGitHubIssueService
-    {
-        ValueTask<Issue> PostIssueAsync(
-            string owner, string name, string token, NewIssue newIssue);
+    ValueTask<Issue> PostIssueAsync(
+        string owner, string name, string token, NewIssue newIssue);
 
-        ValueTask<Issue> UpdateIssueAsync(
-            string owner, string name, string token, long number, IssueUpdate issueUpdate);
-    }
+    ValueTask<Issue> UpdateIssueAsync(
+        string owner, string name, string token, long number, IssueUpdate issueUpdate);
 }

--- a/src/DotNet.GitHub/IGitHubLabelService.cs
+++ b/src/DotNet.GitHub/IGitHubLabelService.cs
@@ -1,14 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading.Tasks;
-using Octokit;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public interface IGitHubLabelService
 {
-    public interface IGitHubLabelService
-    {
-        ValueTask<Label> GetOrCreateLabelAsync(
-            string owner, string name, string token);
-    }
+    ValueTask<Label> GetOrCreateLabelAsync(
+        string owner, string name, string token);
 }

--- a/src/DotNet.GitHub/IResilientGitHubClientFactory.cs
+++ b/src/DotNet.GitHub/IResilientGitHubClientFactory.cs
@@ -1,12 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Octokit;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public interface IResilientGitHubClientFactory
 {
-    public interface IResilientGitHubClientFactory
-    {
-        IGitHubClient Create(string token);
-    }
+    IGitHubClient Create(string token);
 }

--- a/src/DotNet.GitHub/ModelExtensions.cs
+++ b/src/DotNet.GitHub/ModelExtensions.cs
@@ -100,7 +100,7 @@ namespace DotNet.GitHub
             IMarkdownDocument document = new MarkdownDocument();
 
             var uniqueProjects =
-                projects.DistinctBy(project => project.FullPath, StringComparer.OrdinalIgnoreCase)
+                projects.DistinctBy(project => project.FullPath)
                     .OrderBy(project => project.FullPath)
                     .ToList();
 

--- a/src/DotNet.GitHub/ModelExtensions.cs
+++ b/src/DotNet.GitHub/ModelExtensions.cs
@@ -1,47 +1,35 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using DotNet.Extensions;
-using DotNet.Models;
-using Markdown;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public static class ModelExtensions
 {
-    public static class ModelExtensions
+    public static string ToMarkdownBody(
+        this ISet<ProjectSupportReport> psrs,
+        string tfm,
+        string rootDirectory,
+        string branch)
     {
-        static (string FileName, HashSet<TargetFrameworkMonikerSupport> Tfms) AsNameSetPair(
-            this ProjectSupportReport psr) =>
-            (Path.GetFileName(psr.Project.FullPath), psr.TargetFrameworkMonikerSupports);
+        IMarkdownDocument document = new MarkdownDocument();
 
-        public static string ToMarkdownBody(
-            this ISet<ProjectSupportReport> psrs,
-            string tfm,
-            string rootDirectory,
-            string branch)
-        {
-            IMarkdownDocument document = new MarkdownDocument();
+        document.AppendParagraph(
+            "The following project file(s) target a .NET version which is no longer supported. " +
+            "This is an auto-generated issue, detailed and discussed in [dotnet/docs#22271](https://github.com/dotnet/docs/issues/22271).");
 
-            document.AppendParagraph(
-                "The following project file(s) target a .NET version which is no longer supported. " +
-                "This is an auto-generated issue, detailed and discussed in [dotnet/docs#22271](https://github.com/dotnet/docs/issues/22271).");
+        var tfmSupport =
+            psrs.First()
+                .TargetFrameworkMonikerSupports
+                .First(tfms => tfms.TargetFrameworkMoniker == tfm);
 
-            var tfmSupport =
-                psrs.First()
-                    .TargetFrameworkMonikerSupports
-                    .First(tfms => tfms.TargetFrameworkMoniker == tfm);
-
-            document.AppendTable(
-                new MarkdownTableHeader(
-                    new("Target version"),
-                    new("End of life"),
-                    new("Release notes"),
-                    new("Nearest LTS TFM version")),
-                new[]
-                {
+        document.AppendTable(
+            new MarkdownTableHeader(
+                new("Target version"),
+                new("End of life"),
+                new("Release notes"),
+                new("Nearest LTS TFM version")),
+            new[]
+            {
                     new MarkdownTableRow(
                     $"`{tfmSupport.TargetFrameworkMoniker}`",
                     tfmSupport.Release.EndOfLifeDate.HasValue
@@ -50,104 +38,103 @@ namespace DotNet.GitHub
                         $"{tfmSupport.TargetFrameworkMoniker} release notes", tfmSupport.Release.ReleaseNotesUrl)
                         .ToString(),
                     $"`{tfmSupport.NearestLtsVersion}`")
-                });
+            });
 
-            document.AppendList(
-                new MarkdownList(
-                    psrs.OrderBy(psr => psr.Project.FullPath).Select(psr =>
-                    {
-                        var relativePath =
-                            Path.GetRelativePath(rootDirectory, psr.Project.FullPath);
+        document.AppendList(
+            new MarkdownList(
+                psrs.OrderBy(psr => psr.Project.FullPath).Select(psr =>
+                {
+                    var relativePath =
+                        Path.GetRelativePath(rootDirectory, psr.Project.FullPath);
 
-                        var lineNumberFileReference =
-                            $"../blob/{branch}/{relativePath.Replace("\\", "/")}#L{psr.Project.TfmLineNumber}"
-                                .EscapeUriString();
-                        var name = relativePath.ShrinkPath("...");
+                    var lineNumberFileReference =
+                        $"../blob/{branch}/{relativePath.Replace("\\", "/")}#L{psr.Project.TfmLineNumber}"
+                            .EscapeUriString();
+                    var name = relativePath.ShrinkPath("...");
 
-                        return new MarkdownCheckListItem(false, $"[{name}]({lineNumberFileReference})");
-                    })));
+                    return new MarkdownCheckListItem(false, $"[{name}]({lineNumberFileReference})");
+                })));
 
-            document.AppendParagraph(
-                "Consider upgrading projects to either the current release, or the nearest LTS TFM version.");
+        document.AppendParagraph(
+            "Consider upgrading projects to either the current release, or the nearest LTS TFM version.");
 
-            document.AppendParagraph(
-                $"If any of these projects are intentionally targeting an unsupported version, " +
-                $"you can optionally configure to ignore including them in this automated issue. " +
-                $"Create a file at the root of the repository, named *dotnet-versionsweeper.json* and " +
-                $"add an `ignore` entry following the " +
-                $"[globbing patterns detailed here](https://docs.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing.matcher#remarks).");
+        document.AppendParagraph(
+            $"If any of these projects are intentionally targeting an unsupported version, " +
+            $"you can optionally configure to ignore including them in this automated issue. " +
+            $"Create a file at the root of the repository, named *dotnet-versionsweeper.json* and " +
+            $"add an `ignore` entry following the " +
+            $"[globbing patterns detailed here](https://docs.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing.matcher#remarks).");
 
-            document.AppendCode("json", @"{
+        document.AppendCode("json", @"{
     ""ignore"": [
         ""**/path/to/example.csproj""
     ]
 }");
-            return document.ToString();
-        }
+        return document.ToString();
+    }
 
-        public static bool TryCreateIssueContent(
-            this ISet<Project> projects,
-            string rootDirectory,
-            string branch,
-            out (string Title, string MarkdownBody) result)
+    public static bool TryCreateIssueContent(
+        this ISet<ModelProject> projects,
+        string rootDirectory,
+        string branch,
+        out (string Title, string MarkdownBody) result)
+    {
+        if (projects is { Count: 0 })
         {
-            if (projects is { Count: 0 })
-            {
-                result = (null!, null!);
-                return false;
-            }
+            result = (null!, null!);
+            return false;
+        }
 
-            IMarkdownDocument document = new MarkdownDocument();
+        IMarkdownDocument document = new MarkdownDocument();
 
-            var uniqueProjects =
-                projects.DistinctBy(project => project.FullPath)
-                    .OrderBy(project => project.FullPath)
-                    .ToList();
+        var uniqueProjects =
+            projects.DistinctBy(project => project.FullPath)
+                .OrderBy(project => project.FullPath)
+                .ToList();
 
-            document.AppendParagraph(
-                $"There are {uniqueProjects.Count} project(s) using the non-SDK-style project format. " +
-                "This is an auto-generated issue, detailed and discussed in [dotnet/docs#22271](https://github.com/dotnet/docs/issues/22271).");
+        document.AppendParagraph(
+            $"There are {uniqueProjects.Count} project(s) using the non-SDK-style project format. " +
+            "This is an auto-generated issue, detailed and discussed in [dotnet/docs#22271](https://github.com/dotnet/docs/issues/22271).");
 
-            static MarkdownCheckListItem AsCheckListItem(
-                Project project, string root, string branch)
-            {
-                var relativePath =
-                    Path.GetRelativePath(root, project.FullPath);
+        static MarkdownCheckListItem AsCheckListItem(
+            ModelProject project, string root, string branch)
+        {
+            var relativePath =
+                Path.GetRelativePath(root, project.FullPath);
 
-                var path = $"../blob/{branch}/{relativePath.Replace("\\", "/")}".EscapeUriString();
-                var name = relativePath.ShrinkPath("...");
+            var path = $"../blob/{branch}/{relativePath.Replace("\\", "/")}".EscapeUriString();
+            var name = relativePath.ShrinkPath("...");
 
-                return new(false, $"[{name}]({path})");
-            }
+            return new(false, $"[{name}]({path})");
+        }
 
-            document.AppendList(
-                new MarkdownList(
-                    uniqueProjects
-                        .Select(proj => AsCheckListItem(proj, rootDirectory, branch))));
+        document.AppendList(
+            new MarkdownList(
+                uniqueProjects
+                    .Select(proj => AsCheckListItem(proj, rootDirectory, branch))));
 
-            document.AppendParagraph(
-                "Consider upgrading the project(s) to the [SDK-style format](https://docs.microsoft.com/dotnet/standard/frameworks).");
+        document.AppendParagraph(
+            "Consider upgrading the project(s) to the [SDK-style format](https://docs.microsoft.com/dotnet/standard/frameworks).");
 
-            document.AppendParagraph(
-                $"If this project is intentionally demonstrating the old project style, " +
-                $"you can optionally configure to ignore this automated issue. " +
-                $"Create a file at the root of the repository, named *dotnet-versionsweeper.json* and " +
-                $"add an `ignore` entry following the " +
-                $"[globbing patterns detailed here](https://docs.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing.matcher#remarks).");
+        document.AppendParagraph(
+            $"If this project is intentionally demonstrating the old project style, " +
+            $"you can optionally configure to ignore this automated issue. " +
+            $"Create a file at the root of the repository, named *dotnet-versionsweeper.json* and " +
+            $"add an `ignore` entry following the " +
+            $"[globbing patterns detailed here](https://docs.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing.matcher#remarks).");
 
-            document.AppendCode("json", @"{
+        document.AppendCode("json", @"{
     ""ignore"": [
         ""**/path/to/example.csproj""
     ]
 }");
 
-            result =
-                (
-                    Title: "Upgrade project(s) to the SDK-style project format",
-                    MarkdownBody: document.ToString()
-                );
+        result =
+            (
+                Title: "Upgrade project(s) to the SDK-style project format",
+                MarkdownBody: document.ToString()
+            );
 
-            return true;
-        }
+        return true;
     }
 }

--- a/src/DotNet.GitHub/RateLimitAwareQueue.cs
+++ b/src/DotNet.GitHub/RateLimitAwareQueue.cs
@@ -1,62 +1,55 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Octokit;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public class RateLimitAwareQueue
 {
-    public class RateLimitAwareQueue
+    const int DelayBetweenPostCalls = 1_000;
+
+    readonly HashSet<string> _unqiueNewIssueTitles = new(StringComparer.OrdinalIgnoreCase);
+    readonly ConcurrentQueue<(GitHubApiArgs, NewIssue)> _newIssuesQueue = new();
+    readonly ConcurrentQueue<(GitHubApiArgs, IssueUpdate)> _updateIssuesQueue = new();
+    readonly IGitHubIssueService _gitHubIssueService;
+
+    public RateLimitAwareQueue(IGitHubIssueService gitHubIssueService) =>
+        _gitHubIssueService = gitHubIssueService;
+
+    public void Enqueue(GitHubApiArgs args, NewIssue issue)
     {
-        const int DelayBetweenPostCalls = 1_000;
-
-        readonly HashSet<string> _unqiueNewIssueTitles = new(StringComparer.OrdinalIgnoreCase);
-        readonly ConcurrentQueue<(GitHubApiArgs, NewIssue)> _newIssuesQueue = new();
-        readonly ConcurrentQueue<(GitHubApiArgs, IssueUpdate)> _updateIssuesQueue = new();
-        readonly IGitHubIssueService _gitHubIssueService;
-
-        public RateLimitAwareQueue(IGitHubIssueService gitHubIssueService) =>
-            _gitHubIssueService = gitHubIssueService;
-
-        public void Enqueue(GitHubApiArgs args, NewIssue issue)
+        if (_unqiueNewIssueTitles.Add(issue.Title))
         {
-            if (_unqiueNewIssueTitles.Add(issue.Title))
-            {
-                _newIssuesQueue.Enqueue((args, issue));
-            }
+            _newIssuesQueue.Enqueue((args, issue));
+        }
+    }
+
+    public void Enqueue(GitHubApiArgs args, IssueUpdate issue) =>
+        _updateIssuesQueue.Enqueue((args, issue));
+
+    public async IAsyncEnumerable<(string Type, Issue Issue)> ExecuteAllQueuedItemsAsync()
+    {
+        while (_newIssuesQueue is { IsEmpty: false }
+            && _newIssuesQueue.TryDequeue(out (GitHubApiArgs, NewIssue) newItem))
+        {
+            var (args, newIssue) = newItem;
+            var issue = await _gitHubIssueService.PostIssueAsync(
+                args.Owner, args.RepoName, args.Token, newIssue);
+
+            yield return ("Created", issue);
+
+            await Task.Delay(DelayBetweenPostCalls);
         }
 
-        public void Enqueue(GitHubApiArgs args, IssueUpdate issue) =>
-            _updateIssuesQueue.Enqueue((args, issue));
-
-        public async IAsyncEnumerable<(string Type, Issue Issue)> ExecuteAllQueuedItemsAsync()
+        while (_updateIssuesQueue is { IsEmpty: false }
+            && _updateIssuesQueue.TryDequeue(out (GitHubApiArgs, IssueUpdate) updatedItem))
         {
-            while (_newIssuesQueue is { IsEmpty: false }
-                && _newIssuesQueue.TryDequeue(out (GitHubApiArgs, NewIssue) newItem))
-            {
-                var (args, newIssue) = newItem;
-                var issue = await _gitHubIssueService.PostIssueAsync(
-                    args.Owner, args.RepoName, args.Token, newIssue);
+            var (args, newIssue) = updatedItem;
+            var issue = await _gitHubIssueService.UpdateIssueAsync(
+                args.Owner, args.RepoName, args.Token, args.IssueNumber, newIssue);
 
-                yield return ("Created", issue);
+            yield return ("Updated", issue);
 
-                await Task.Delay(DelayBetweenPostCalls);
-            }
-
-            while (_updateIssuesQueue is { IsEmpty: false }
-                && _updateIssuesQueue.TryDequeue(out (GitHubApiArgs, IssueUpdate) updatedItem))
-            {
-                var (args, newIssue) = updatedItem;
-                var issue = await _gitHubIssueService.UpdateIssueAsync(
-                    args.Owner, args.RepoName, args.Token, args.IssueNumber, newIssue);
-
-                yield return ("Updated", issue);
-
-                await Task.Delay(DelayBetweenPostCalls);
-            }
+            await Task.Delay(DelayBetweenPostCalls);
         }
     }
 }

--- a/src/DotNet.GitHub/Records.cs
+++ b/src/DotNet.GitHub/Records.cs
@@ -1,20 +1,19 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DotNet.GitHub
+namespace DotNet.GitHub;
+
+public record GraphQLResult<T>
 {
-    public record GraphQLResult<T>
-    {
-        public Data<T>? Data { get; init; }
-    }
+    public Data<T>? Data { get; init; }
+}
 
-    public record Data<T>
-    {
-        public Search<T>? Search { get; init; }
-    }
+public record Data<T>
+{
+    public Search<T>? Search { get; init; }
+}
 
-    public record Search<T>
-    {
-        public T[]? Nodes { get; init; }
-    }
+public record Search<T>
+{
+    public T[]? Nodes { get; init; }
 }

--- a/src/DotNet.GitHub/ServiceCollectionExtensions.cs
+++ b/src/DotNet.GitHub/ServiceCollectionExtensions.cs
@@ -1,25 +1,21 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.DependencyInjection;
-using Octokit.Extensions;
+namespace DotNet.GitHub;
 
-namespace DotNet.GitHub
+public static class ServiceCollectionExtensions
 {
-    public static class ServiceCollectionExtensions
+    public static IServiceCollection AddDotNetGitHubServices(
+        this IServiceCollection services)
     {
-        public static IServiceCollection AddDotNetGitHubServices(
-            this IServiceCollection services)
-        {
-            services.AddHttpClient<GitHubGraphQLClient>();
+        services.AddHttpClient<GitHubGraphQLClient>();
 
-            return services
-                .AddSingleton<ResilientGitHubClientFactory>()
-                .AddSingleton<IResilientGitHubClientFactory, DefaultResilientGitHubClientFactory>()
-                .AddSingleton<GitHubGraphQLClient>()
-                .AddSingleton<RateLimitAwareQueue>()
-                .AddSingleton<IGitHubIssueService, GitHubIssueService>()
-                .AddSingleton<IGitHubLabelService, GitHubLabelService>();
-        }
+        return services
+            .AddSingleton<ResilientGitHubClientFactory>()
+            .AddSingleton<IResilientGitHubClientFactory, DefaultResilientGitHubClientFactory>()
+            .AddSingleton<GitHubGraphQLClient>()
+            .AddSingleton<RateLimitAwareQueue>()
+            .AddSingleton<IGitHubIssueService, GitHubIssueService>()
+            .AddSingleton<IGitHubLabelService, GitHubLabelService>();
     }
 }

--- a/src/DotNet.GitHubActions/Commands.cs
+++ b/src/DotNet.GitHubActions/Commands.cs
@@ -1,21 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DotNet.GitHubActions
+namespace DotNet.GitHubActions;
+
+public static class Commands
 {
-    public static class Commands
-    {
-        public const string SetEnv = "set-env";
-        public const string AddMask = "add-mask";
-        public const string AddPath = "add-path";
-        public const string SetOutput = "set-output";
-        public const string Echo = "echo";
-        public const string Debug = "debug";
-        public const string Error = "error";
-        public const string Warning = "warning";
-        public const string Info = "info";
-        public const string Group = "group";
-        public const string EndGroup = "endgroup";
-        public const string SaveState = "save-state";
-    }
+    public const string SetEnv = "set-env";
+    public const string AddMask = "add-mask";
+    public const string AddPath = "add-path";
+    public const string SetOutput = "set-output";
+    public const string Echo = "echo";
+    public const string Debug = "debug";
+    public const string Error = "error";
+    public const string Warning = "warning";
+    public const string Info = "info";
+    public const string Group = "group";
+    public const string EndGroup = "endgroup";
+    public const string SaveState = "save-state";
 }

--- a/src/DotNet.GitHubActions/DotNet.GitHubActions.csproj
+++ b/src/DotNet.GitHubActions/DotNet.GitHubActions.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/DotNet.GitHubActions/DotNet.GitHubActions.csproj
+++ b/src/DotNet.GitHubActions/DotNet.GitHubActions.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/DotNet.GitHubActions/ExitCode.cs
+++ b/src/DotNet.GitHubActions/ExitCode.cs
@@ -1,21 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DotNet.GitHubActions
+namespace DotNet.GitHubActions;
+
+/// <summary>
+/// The code to exit an action
+/// </summary>
+public enum ExitCode
 {
     /// <summary>
-    /// The code to exit an action
+    ///  A code indicating that the action was successful
     /// </summary>
-    public enum ExitCode
-    {
-        /// <summary>
-        ///  A code indicating that the action was successful
-        /// </summary>
-        Success = 0,
+    Success = 0,
 
-        /// <summary>
-        /// A code indicating that the action was a failure
-        /// </summary>
-        Failure = 1
-    }
+    /// <summary>
+    /// A code indicating that the action was a failure
+    /// </summary>
+    Failure = 1
 }

--- a/src/DotNet.GitHubActions/IJobService.cs
+++ b/src/DotNet.GitHubActions/IJobService.cs
@@ -1,120 +1,115 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+namespace DotNet.GitHubActions;
 
-namespace DotNet.GitHubActions
+/// <summary>
+/// Based on https://github.com/actions/toolkit/blob/main/packages/core/src/core.ts
+/// </summary>
+public interface IJobService
 {
+    bool IsDebug();
+
+    void ExportVariable<T>(string name, T? value = default);
+
+    void SetSecret(string secret);
+
+    void AddPath(string inputPath);
+
+    string GetInput(string name, InputOptions? options = default);
+
     /// <summary>
-    /// Based on https://github.com/actions/toolkit/blob/main/packages/core/src/core.ts
+    /// Writes the given <paramref name="properties"/> and <paramref name="message"/> arguments
+    /// in the following format: "::set-output {properties}::{message}", for example:
+    /// "::set-output key-1=some initial value, key-2=anthor value::Hi friends!" when
+    /// <paramref name="message"/> is "Hi friends!" and <paramref name="properties"/> is 
+    /// new Dictionary{string, string} {  ["key-1"] = "some initial value", ["key-2"] = "another value" });
     /// </summary>
-    public interface IJobService
+    /// <example>
+    /// <code language="c#">
+    /// <![CDATA[
+    /// IJobService job = new DefaultJobService();
+    ///
+    /// // ::set-output::Hi friends!
+    /// job.SetOutput("Hi friends");
+    /// 
+    /// // ::set-output prop1=Value 1, prop2=Value 2::
+    /// job.SetOutput(
+    ///      properties: new Dictionary<string, string>
+    ///      {
+    ///          ["prop1"] = "Value 1",
+    ///          ["prop2"] = "Value 2"
+    ///      });
+    ///
+    /// // ::set-output prop1=Value 1, prop2=Value 2::Hi friends!
+    /// job.SetOutput(
+    ///      message: "Hi friends",
+    ///      properties: new Dictionary<string, string>
+    ///      {
+    ///          ["prop1] = "Value 1",
+    ///          ["prop2"] = "Value 2"
+    ///      });
+    /// ]]>
+    /// </code>
+    /// </example>
+    void SetOutput(string? message, Dictionary<string, string>? properties = default);
+
+    void SetCommandEcho(bool enabled);
+
+    void SetFailed(string message, int? exitCode = null);
+
+    void Debug(string? message);
+
+    void Error(string? message);
+
+    void Warning(string? message);
+
+    void Info(string? message);
+
+    void StartGroup(string name);
+
+    void EndGroup();
+
+    async Task<T> GroupAsync<T>(string name, Func<Task<T>> func) where T : notnull
     {
-        bool IsDebug();
+        StartGroup(name);
 
-        void ExportVariable<T>(string name, T? value = default);
-
-        void SetSecret(string secret);
-
-        void AddPath(string inputPath);
-
-        string GetInput(string name, InputOptions? options = default);
-
-        /// <summary>
-        /// Writes the given <paramref name="properties"/> and <paramref name="message"/> arguments
-        /// in the following format: "::set-output {properties}::{message}", for example:
-        /// "::set-output key-1=some initial value, key-2=anthor value::Hi friends!" when
-        /// <paramref name="message"/> is "Hi friends!" and <paramref name="properties"/> is 
-        /// new Dictionary{string, string} {  ["key-1"] = "some initial value", ["key-2"] = "another value" });
-        /// </summary>
-        /// <example>
-        /// <code language="c#">
-        /// <![CDATA[
-        /// IJobService job = new DefaultJobService();
-        ///
-        /// // ::set-output::Hi friends!
-        /// job.SetOutput("Hi friends");
-        /// 
-        /// // ::set-output prop1=Value 1, prop2=Value 2::
-        /// job.SetOutput(
-        ///      properties: new Dictionary<string, string>
-        ///      {
-        ///          ["prop1"] = "Value 1",
-        ///          ["prop2"] = "Value 2"
-        ///      });
-        ///
-        /// // ::set-output prop1=Value 1, prop2=Value 2::Hi friends!
-        /// job.SetOutput(
-        ///      message: "Hi friends",
-        ///      properties: new Dictionary<string, string>
-        ///      {
-        ///          ["prop1] = "Value 1",
-        ///          ["prop2"] = "Value 2"
-        ///      });
-        /// ]]>
-        /// </code>
-        /// </example>
-        void SetOutput(string? message, Dictionary<string, string>? properties = default);
-
-        void SetCommandEcho(bool enabled);
-
-        void SetFailed(string message, int? exitCode = null);
-
-        void Debug(string? message);
-
-        void Error(string? message);
-
-        void Warning(string? message);
-
-        void Info(string? message);
-
-        void StartGroup(string name);
-
-        void EndGroup();
-
-        async Task<T> GroupAsync<T>(string name, Func<Task<T>> func) where T : notnull
+        T result;
+        try
         {
-            StartGroup(name);
-
-            T result;
-            try
-            {
-                result = await func();
-            }
-            finally
-            {
-                EndGroup();
-            }
-
-            return result;
+            result = await func();
+        }
+        finally
+        {
+            EndGroup();
         }
 
-        /// <summary>
-        /// Writes the given <paramref name="stateName"/> and <paramref name="state"/> arguments
-        /// in the following format: "::save-state name={stateName}::{state}", for example:
-        /// "::save-state name=state-7::The number seven" when
-        /// <paramref name="stateName"/> is "state-7" and <paramref name="state"/> is "The number seven"
-        /// </summary>
-        /// <example>
-        /// <code language="c#">
-        /// <![CDATA[
-        /// IJobService job = new DefaultJobService();
-        ///
-        /// // ::save-state name=state_1::Hi friends!
-        /// job.SaveState("state_1", "Hi friends");
-        ///
-        /// // ::save-state name=state_2::2
-        /// job.SaveState("state_2", 2);
-        ///
-        /// // ::save-state name=state_3::false
-        /// job.SaveState("state_3", false);
-        /// ]]>
-        /// </code>
-        /// </example>
-        void SaveState<T>(string stateName, T? state = default);
-
-        string GetState(string name);
+        return result;
     }
+
+    /// <summary>
+    /// Writes the given <paramref name="stateName"/> and <paramref name="state"/> arguments
+    /// in the following format: "::save-state name={stateName}::{state}", for example:
+    /// "::save-state name=state-7::The number seven" when
+    /// <paramref name="stateName"/> is "state-7" and <paramref name="state"/> is "The number seven"
+    /// </summary>
+    /// <example>
+    /// <code language="c#">
+    /// <![CDATA[
+    /// IJobService job = new DefaultJobService();
+    ///
+    /// // ::save-state name=state_1::Hi friends!
+    /// job.SaveState("state_1", "Hi friends");
+    ///
+    /// // ::save-state name=state_2::2
+    /// job.SaveState("state_2", 2);
+    ///
+    /// // ::save-state name=state_3::false
+    /// job.SaveState("state_3", false);
+    /// ]]>
+    /// </code>
+    /// </example>
+    void SaveState<T>(string stateName, T? state = default);
+
+    string GetState(string name);
 }

--- a/src/DotNet.GitHubActions/InputOptions.cs
+++ b/src/DotNet.GitHubActions/InputOptions.cs
@@ -1,13 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DotNet.GitHubActions
+namespace DotNet.GitHubActions;
+
+public record InputOptions
 {
-    public record InputOptions
-    {
-        /// <summary>
-        /// Optional. Whether the input is required. If required and not present, will throw. Defaults to false
-        /// </summary>
-        public bool? Required { get; init; }
-    }
+    /// <summary>
+    /// Optional. Whether the input is required. If required and not present, will throw. Defaults to false
+    /// </summary>
+    public bool? Required { get; init; }
 }

--- a/src/DotNet.GitHubActions/JobService.cs
+++ b/src/DotNet.GitHubActions/JobService.cs
@@ -1,116 +1,112 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Text;
 
-namespace DotNet.GitHubActions
+namespace DotNet.GitHubActions;
+
+public class JobService : IJobService
 {
-    public class JobService : IJobService
+    /// <inheritdoc />
+    public void AddPath(string inputPath)
     {
-        /// <inheritdoc />
-        public void AddPath(string inputPath)
+        IssueCommand(Commands.AddPath, message: inputPath);
+        Environment.SetEnvironmentVariable(
+            "PATH", $"{inputPath}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}");
+    }
+
+    /// <inheritdoc />
+    public bool IsDebug() => Environment.GetEnvironmentVariable("RUNNER_DEBUG") == "1";
+    /// <inheritdoc />
+    public void Info(string? message) => Console.WriteLine(message);
+    /// <inheritdoc />
+    public void Debug(string? message) => IssueCommand(Commands.Debug, message: message);
+    /// <inheritdoc />
+    public void Error(string? message) => IssueCommand(Commands.Error, message: message);
+    /// <inheritdoc />
+    public void Warning(string? message) => IssueCommand(Commands.Warning, message: message);
+    /// <inheritdoc />
+    public void SetSecret(string secret) => IssueCommand(Commands.AddMask, message: secret);
+    /// <inheritdoc />
+    public void StartGroup(string name) => IssueCommand(Commands.Group, message: name);
+    /// <inheritdoc />
+    public void EndGroup() => IssueCommand<object>(Commands.EndGroup);
+    /// <inheritdoc />
+    public void SetCommandEcho(bool enabled) => IssueCommand(Commands.Echo, message: enabled ? "on" : "off");
+    /// <inheritdoc />
+    public string GetState(string name) => Environment.GetEnvironmentVariable($"STATE_{name}") ?? "";
+
+    /// <inheritdoc />
+    public void ExportVariable<T>(string name, T? value)
+    {
+        var convertedValue = value.ToCommandValue();
+        Environment.SetEnvironmentVariable(name, convertedValue);
+
+        var filePath = Environment.GetEnvironmentVariable("GITHUB_ENV") ?? "";
+        if (filePath is { Length: > 0 })
         {
-            IssueCommand(Commands.AddPath, message: inputPath);
-            Environment.SetEnvironmentVariable(
-                "PATH", $"{inputPath}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}");
+            var delimiter = "_GitHubActionsFileCommandDelimeter_";
+            var commandValue = $"{name}<<{delimiter}{Environment.NewLine}{convertedValue}{Environment.NewLine}{delimiter}";
+            IssueFileCommand("ENV", commandValue);
+        }
+        else
+        {
+            IssueCommand(Commands.SetEnv, message: convertedValue);
+        }
+    }
+
+    /// <inheritdoc />
+    public string GetInput(string name, InputOptions? options = default)
+    {
+        var value = Environment.GetEnvironmentVariable(
+            $"INPUT_{name.Replace(" ", "_").ToUpper()}") ?? "";
+
+        return options?.Required ?? false && value is { Length: 0 }
+            ? throw new($"Input required and not supplied: {name}")
+            : value.Trim();
+    }
+
+    /// <inheritdoc />
+    public void SaveState<T>(string stateName, T? stateValue) =>
+        IssueCommand(Commands.SaveState, new() { ["name"] = stateName }, stateValue);
+
+    /// <inheritdoc />
+    public void SetFailed(string message, int? exitCode = null)
+    {
+        Error(message);
+        Environment.Exit(exitCode ?? (int)ExitCode.Failure);
+    }
+
+    /// <inheritdoc />
+    public void SetOutput(string? message, Dictionary<string, string>? properties = default) =>
+        IssueCommand(Commands.SetOutput, properties, message);
+
+    static void IssueCommand<T>(
+        string commandName,
+        Dictionary<string, string>? properties = default,
+        T? message = default)
+    {
+        WorkflowCommand<T> workflowCommand = new(commandName, message, properties);
+        Console.WriteLine(workflowCommand.ToString());
+    }
+
+    static void IssueFileCommand(
+        string command,
+        object? message)
+    {
+        var filePath = Environment.GetEnvironmentVariable($"GITHUB_{command}") ?? "";
+        if (filePath is { Length: > 0 })
+        {
+            throw new(
+                $"Unable to find environment variable for file command {command}");
         }
 
-        /// <inheritdoc />
-        public bool IsDebug() => Environment.GetEnvironmentVariable("RUNNER_DEBUG") == "1";
-        /// <inheritdoc />
-        public void Info(string? message) => Console.WriteLine(message);
-        /// <inheritdoc />
-        public void Debug(string? message) => IssueCommand(Commands.Debug, message: message);
-        /// <inheritdoc />
-        public void Error(string? message) => IssueCommand(Commands.Error, message: message);
-        /// <inheritdoc />
-        public void Warning(string? message) => IssueCommand(Commands.Warning, message: message);
-        /// <inheritdoc />
-        public void SetSecret(string secret) => IssueCommand(Commands.AddMask, message: secret);
-        /// <inheritdoc />
-        public void StartGroup(string name) => IssueCommand(Commands.Group, message: name);
-        /// <inheritdoc />
-        public void EndGroup() => IssueCommand<object>(Commands.EndGroup);
-        /// <inheritdoc />
-        public void SetCommandEcho(bool enabled) => IssueCommand(Commands.Echo, message: enabled ? "on" : "off");
-        /// <inheritdoc />
-        public string GetState(string name) => Environment.GetEnvironmentVariable($"STATE_{name}") ?? "";
-
-        /// <inheritdoc />
-        public void ExportVariable<T>(string name, T? value)
+        if (!File.Exists(filePath))
         {
-            var convertedValue = value.ToCommandValue();
-            Environment.SetEnvironmentVariable(name, convertedValue);
-
-            var filePath = Environment.GetEnvironmentVariable("GITHUB_ENV") ?? "";
-            if (filePath is { Length: > 0 })
-            {
-                var delimiter = "_GitHubActionsFileCommandDelimeter_";
-                var commandValue = $"{name}<<{delimiter}{Environment.NewLine}{convertedValue}{Environment.NewLine}{delimiter}";
-                IssueFileCommand("ENV", commandValue);
-            }
-            else
-            {
-                IssueCommand(Commands.SetEnv, message: convertedValue);
-            }
+            throw new($"Missing file at path: {filePath}");
         }
 
-        /// <inheritdoc />
-        public string GetInput(string name, InputOptions? options = default)
-        {
-            var value = Environment.GetEnvironmentVariable(
-                $"INPUT_{name.Replace(" ", "_").ToUpper()}") ?? "";
-
-            return options?.Required ?? false && value is { Length: 0 }
-                ? throw new($"Input required and not supplied: {name}")
-                : value.Trim();
-        }
-
-        /// <inheritdoc />
-        public void SaveState<T>(string stateName, T? stateValue) =>
-            IssueCommand(Commands.SaveState, new() { ["name"] = stateName }, stateValue);
-
-        /// <inheritdoc />
-        public void SetFailed(string message, int? exitCode = null)
-        {
-            Error(message);
-            Environment.Exit(exitCode ?? (int)ExitCode.Failure);
-        }
-
-        /// <inheritdoc />
-        public void SetOutput(string? message, Dictionary<string, string>? properties = default) =>
-            IssueCommand(Commands.SetOutput, properties, message);
-
-        static void IssueCommand<T>(
-            string commandName,
-            Dictionary<string, string>? properties = default,
-            T? message = default)
-        {
-            WorkflowCommand<T> workflowCommand = new(commandName, message, properties);
-            Console.WriteLine(workflowCommand.ToString());
-        }
-
-        static void IssueFileCommand(
-            string command,
-            object? message)
-        {
-            var filePath = Environment.GetEnvironmentVariable($"GITHUB_{command}") ?? "";
-            if (filePath is { Length: > 0 })
-            {
-                throw new(
-                    $"Unable to find environment variable for file command {command}");
-            }
-
-            if (!File.Exists(filePath))
-            {
-                throw new($"Missing file at path: {filePath}");
-            }
-
-            File.AppendAllText(
-                filePath, $"{message.ToCommandValue()}{Environment.NewLine}", Encoding.UTF8);
-        }
+        File.AppendAllText(
+            filePath, $"{message.ToCommandValue()}{Environment.NewLine}", Encoding.UTF8);
     }
 }

--- a/src/DotNet.GitHubActions/ServiceCollectionExtensions.cs
+++ b/src/DotNet.GitHubActions/ServiceCollectionExtensions.cs
@@ -3,11 +3,10 @@
 
 using Microsoft.Extensions.DependencyInjection;
 
-namespace DotNet.GitHubActions
+namespace DotNet.GitHubActions;
+
+public static class ServiceCollectionExtensions
 {
-    public static class ServiceCollectionExtensions
-    {
-        public static IServiceCollection AddGitHubActionServices(
-            this IServiceCollection services) => services.AddSingleton<IJobService, JobService>();
-    }
+    public static IServiceCollection AddGitHubActionServices(
+        this IServiceCollection services) => services.AddSingleton<IJobService, JobService>();
 }

--- a/src/DotNet.GitHubActions/WorkflowCommand.cs
+++ b/src/DotNet.GitHubActions/WorkflowCommand.cs
@@ -1,95 +1,91 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace DotNet.GitHubActions
+namespace DotNet.GitHubActions;
+
+/// <summary>
+/// {commandName} is the command name, example:
+///     "::set-output::"
+///     "::{commandName}::"
+///      when {commandName} is "set-output"
+/// {message} is a string, example:
+///     "::set-output::Hello World!"
+///     "::set-output::{message}"
+///     when {message} is "Hello World!"
+/// {properties} is a Dictionary{string, string}, example:
+///     "::set-output prop1=Value 1, value 2::Hi"
+///     "::set-output {properties}::{message}"
+///     when {message} is "Hi"
+///     and {properties} is
+///         new Dictionary{string, string}
+///         {
+///             ["prop1] = "Value 1",
+///             ["prop2"] = "Value 2"
+///         }
+/// ::{commandName} {properties}::{message}
+/// </summary>
+public record WorkflowCommand<T>(
+    string CommandName,
+    T? Message,
+    IDictionary<string, string>? CommandProperties = default)
 {
-    /// <summary>
-    /// {commandName} is the command name, example:
-    ///     "::set-output::"
-    ///     "::{commandName}::"
-    ///      when {commandName} is "set-output"
-    /// {message} is a string, example:
-    ///     "::set-output::Hello World!"
-    ///     "::set-output::{message}"
-    ///     when {message} is "Hello World!"
-    /// {properties} is a Dictionary{string, string}, example:
-    ///     "::set-output prop1=Value 1, value 2::Hi"
-    ///     "::set-output {properties}::{message}"
-    ///     when {message} is "Hi"
-    ///     and {properties} is
-    ///         new Dictionary{string, string}
-    ///         {
-    ///             ["prop1] = "Value 1",
-    ///             ["prop2"] = "Value 2"
-    ///         }
-    /// ::{commandName} {properties}::{message}
-    /// </summary>
-    public record WorkflowCommand<T>(
-        string CommandName,
-        T? Message,
-        IDictionary<string, string>? CommandProperties = default)
+    const string CMD_STRING = "::";
+
+    public override string ToString()
     {
-        const string CMD_STRING = "::";
+        StringBuilder builder = new($"{CMD_STRING}{CommandName}");
 
-        public override string ToString()
+        if (CommandProperties?.Any() ?? false)
         {
-            StringBuilder builder = new($"{CMD_STRING}{CommandName}");
-
-            if (CommandProperties?.Any() ?? false)
+            foreach (var (first, key, value)
+                in CommandProperties.Select((kvp, i) => (i == 0, kvp.Key, kvp.Value)))
             {
-                foreach (var (first, key, value)
-                    in CommandProperties.Select((kvp, i) => (i == 0, kvp.Key, kvp.Value)))
+                if (!first)
                 {
-                    if (!first)
-                    {
-                        builder.Append(',');
-                    }
-                    builder.Append($" {key}={EscapeProperty(value)}");
+                    builder.Append(',');
                 }
+                builder.Append($" {key}={EscapeProperty(value)}");
             }
-
-            builder.Append($"{CMD_STRING}{EscapeData(Message)}");
-
-            return builder.ToString();
         }
 
-        static string EscapeData<TSource>(TSource? value) =>
-            value.ToCommandValue()
-                .Replace("%", "%25")
-                .Replace("\r", "%0D")
-                .Replace("\n", "%0A");
+        builder.Append($"{CMD_STRING}{EscapeData(Message)}");
 
-        static string EscapeProperty<TSource>(TSource? value) =>
-            value.ToCommandValue()
-                .Replace("%", "%25")
-                .Replace("\r", "%0D")
-                .Replace("\n", "%0A")
-                .Replace(":", "%3A")
-                .Replace(",", "%2C");
+        return builder.ToString();
     }
 
-    static class GenericExtensions
+    static string EscapeData<TSource>(TSource? value) =>
+        value.ToCommandValue()
+            .Replace("%", "%25")
+            .Replace("\r", "%0D")
+            .Replace("\n", "%0A");
+
+    static string EscapeProperty<TSource>(TSource? value) =>
+        value.ToCommandValue()
+            .Replace("%", "%25")
+            .Replace("\r", "%0D")
+            .Replace("\n", "%0A")
+            .Replace(":", "%3A")
+            .Replace(",", "%2C");
+}
+
+static class GenericExtensions
+{
+    static readonly Lazy<JsonSerializerOptions> _lazyOptions = new(() => new()
     {
-        static readonly Lazy<JsonSerializerOptions> _lazyOptions = new(() => new()
-        {
-            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-            PropertyNameCaseInsensitive = true
-        });
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        PropertyNameCaseInsensitive = true
+    });
 
-        internal static string ToCommandValue<T>(this T? value) => value switch
-        {
-            null => string.Empty,
-            string str => str,
-            _ => JsonSerializer.Serialize(value, _lazyOptions.Value)
-        };
-    }
+    internal static string ToCommandValue<T>(this T? value) => value switch
+    {
+        null => string.Empty,
+        string str => str,
+        _ => JsonSerializer.Serialize(value, _lazyOptions.Value)
+    };
 }

--- a/src/DotNet.IO/DotNet.IO.csproj
+++ b/src/DotNet.IO/DotNet.IO.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/DotNet.IO/DotNet.IO.csproj
+++ b/src/DotNet.IO/DotNet.IO.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotNet.IO/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DotNet.IO/Extensions/ServiceCollectionExtensions.cs
@@ -1,16 +1,13 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using DotNet.IO;
+namespace Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.Extensions.DependencyInjection
+public static class ServiceCollectionExtensions
 {
-    public static class ServiceCollectionExtensions
-    {
-        public static IServiceCollection AddDotNetFileSystem(
-            this IServiceCollection services) =>
-            services
-                .AddSingleton<IProjectFileReader, ProjectFileReader>()
-                .AddSingleton<ISolutionFileReader, SolutionFileReader>();
-    }
+    public static IServiceCollection AddDotNetFileSystem(
+        this IServiceCollection services) =>
+        services
+            .AddSingleton<IProjectFileReader, ProjectFileReader>()
+            .AddSingleton<ISolutionFileReader, SolutionFileReader>();
 }

--- a/src/DotNet.IO/GlobalUsings.cs
+++ b/src/DotNet.IO/GlobalUsings.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+global using DotNet.IO;
+global using System.Text.RegularExpressions;
+global using DotNet.Models;
+global using DotNet.Extensions;
+global using System.Text.Json.Serialization;
+global using SystemFile = System.IO.File;

--- a/src/DotNet.IO/Project/IProjectFileReader.cs
+++ b/src/DotNet.IO/Project/IProjectFileReader.cs
@@ -1,13 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading.Tasks;
-using DotNet.Models;
+namespace DotNet.IO;
 
-namespace DotNet.IO
+public interface IProjectFileReader
 {
-    public interface IProjectFileReader
-    {
-        ValueTask<Project> ReadProjectAsync(string projectPath);
-    }
+    ValueTask<Project> ReadProjectAsync(string projectPath);
 }

--- a/src/DotNet.IO/Project/ProjectFileReader.cs
+++ b/src/DotNet.IO/Project/ProjectFileReader.cs
@@ -1,117 +1,108 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using DotNet.Extensions;
-using DotNet.Models;
-using SystemFile = System.IO.File;
+namespace DotNet.IO;
 
-namespace DotNet.IO
+public class ProjectFileReader : IProjectFileReader
 {
-    public class ProjectFileReader : IProjectFileReader
+    static readonly RegexOptions _options =
+        RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.ExplicitCapture;
+    static readonly Regex _projectSdkExpression =
+        new(@"\<Project Sdk=""(?<sdk>.+?)""", _options);
+    static readonly Regex _targetFrameworkExpression =
+        new(@"TargetFramework(.*)>(?<tfm>.+?)</", _options);
+
+    public async ValueTask<Project> ReadProjectAsync(string projectPath)
     {
-        static readonly RegexOptions _options =
-            RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.ExplicitCapture;
-        static readonly Regex _projectSdkExpression =
-            new(@"\<Project Sdk=""(?<sdk>.+?)""", _options);
-        static readonly Regex _targetFrameworkExpression =
-            new(@"TargetFramework(.*)>(?<tfm>.+?)</", _options);
-
-        public async ValueTask<Project> ReadProjectAsync(string projectPath)
+        Project project = new()
         {
-            Project project = new()
+            FullPath = projectPath
+        };
+
+        if (SystemFile.Exists(projectPath))
+        {
+            var projectContent = await SystemFile.ReadAllTextAsync(projectPath);
+            return project.Extension switch
             {
-                FullPath = projectPath
+                ".json" => ParseJson(project, projectContent),
+                _ => ParseXml(project, projectContent)
             };
-
-            if (SystemFile.Exists(projectPath))
-            {
-                var projectContent = await SystemFile.ReadAllTextAsync(projectPath);
-                return project.Extension switch
-                {
-                    ".json" => ParseJson(project, projectContent),
-                    _ => ParseXml(project, projectContent)
-                };
-            }
-
-            return project;
-
-            static Project ParseXml(Project project, string projectContent)
-            {
-                var (index, rawTfms) = MatchExpression(_targetFrameworkExpression, projectContent, "tfm");
-                var lineNumber = GetLineNumberFromIndex(projectContent, index);
-                var (_, sdk) = MatchExpression(_projectSdkExpression, projectContent, "sdk");
-
-                return project with
-                {
-                    TfmLineNumber = lineNumber,
-                    RawTargetFrameworkMonikers = rawTfms!,
-                    Sdk = sdk.NullIfEmpty()
-                };
-            }
-
-            static Project ParseJson(Project project, string projectContent)
-            {
-                var projectJson = projectContent.FromJson<ProjectJson>();
-                if (projectJson is null or { Frameworks: { Count: 0 } })
-                {
-                    return project;
-                }
-
-                var rawTfms = string.Join(";", projectJson.Frameworks.Keys);
-                var lineNumber = GetLineNumberFromProjectJson(
-                    projectJson.Frameworks.Keys.First(), projectContent);
-
-                return project with
-                {
-                    TfmLineNumber = lineNumber,
-                    RawTargetFrameworkMonikers = rawTfms
-                };
-            }
         }
 
-        static int GetLineNumberFromProjectJson(string tfm, string json)
+        return project;
+
+        static Project ParseXml(Project project, string projectContent)
         {
-            var lineNumber = 0;
-            if (json is { Length: > 0 })
+            var (index, rawTfms) = MatchExpression(_targetFrameworkExpression, projectContent, "tfm");
+            var lineNumber = GetLineNumberFromIndex(projectContent, index);
+            var (_, sdk) = MatchExpression(_projectSdkExpression, projectContent, "sdk");
+
+            return project with
             {
-                var lines = json.Split('\n');
-                for (var i = 0; i < lines.Length; ++i)
+                TfmLineNumber = lineNumber,
+                RawTargetFrameworkMonikers = rawTfms!,
+                Sdk = sdk.NullIfEmpty()
+            };
+        }
+
+        static Project ParseJson(Project project, string projectContent)
+        {
+            var projectJson = projectContent.FromJson<ProjectJson>();
+            if (projectJson is null or { Frameworks: { Count: 0 } })
+            {
+                return project;
+            }
+
+            var rawTfms = string.Join(";", projectJson.Frameworks.Keys);
+            var lineNumber = GetLineNumberFromProjectJson(
+                projectJson.Frameworks.Keys.First(), projectContent);
+
+            return project with
+            {
+                TfmLineNumber = lineNumber,
+                RawTargetFrameworkMonikers = rawTfms
+            };
+        }
+    }
+
+    static int GetLineNumberFromProjectJson(string tfm, string json)
+    {
+        var lineNumber = 0;
+        if (json is { Length: > 0 })
+        {
+            var lines = json.Split('\n');
+            for (var i = 0; i < lines.Length; ++i)
+            {
+                if (lines[i]?.Contains(tfm, StringComparison.OrdinalIgnoreCase) ?? false)
                 {
-                    if (lines[i]?.Contains(tfm, StringComparison.OrdinalIgnoreCase) ?? false)
-                    {
-                        lineNumber = i + 1;
-                        break;
-                    }
+                    lineNumber = i + 1;
+                    break;
                 }
             }
-            return lineNumber;
         }
+        return lineNumber;
+    }
 
-        static (int Index, string? Value) MatchExpression(
-            Regex expression, string content, string groupName)
+    static (int Index, string? Value) MatchExpression(
+        Regex expression, string content, string groupName)
+    {
+        var match = expression?.Match(content);
+        if (match is not null)
         {
-            var match = expression?.Match(content);
-            if (match is not null)
-            {
-                var group = match.Groups[groupName];
-                return (group.Index, group.Value);
-            }
-
-            return (0, null);
+            var group = match.Groups[groupName];
+            return (group.Index, group.Value);
         }
 
-        static int GetLineNumberFromIndex(string xml, int index)
+        return (0, null);
+    }
+
+    static int GetLineNumberFromIndex(string xml, int index)
+    {
+        var lineNumber = 1;
+        for (var i = 0; i < index; ++i)
         {
-            var lineNumber = 1;
-            for (var i = 0; i < index; ++i)
-            {
-                if (xml[i] == '\n') ++lineNumber;
-            }
-            return lineNumber;
+            if (xml[i] == '\n') ++lineNumber;
         }
+        return lineNumber;
     }
 }

--- a/src/DotNet.IO/Project/ProjectJson.cs
+++ b/src/DotNet.IO/Project/ProjectJson.cs
@@ -1,18 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
+namespace DotNet.IO;
 
-namespace DotNet.IO
+internal class ProjectJson
 {
-    internal class ProjectJson
-    {
-        [JsonPropertyName("frameworks")]
-        public Dictionary<string, Framework> Frameworks { get; set; } = new();
-    }
+    [JsonPropertyName("frameworks")]
+    public Dictionary<string, Framework> Frameworks { get; set; } = new();
+}
 
-    internal class Framework
-    {
-    }
+internal class Framework
+{
 }

--- a/src/DotNet.IO/Solution/ISolutionFileReader.cs
+++ b/src/DotNet.IO/Solution/ISolutionFileReader.cs
@@ -1,13 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading.Tasks;
-using DotNet.Models;
+namespace DotNet.IO;
 
-namespace DotNet.IO
+public interface ISolutionFileReader
 {
-    public interface ISolutionFileReader
-    {
-        ValueTask<Solution> ReadSolutionAsync(string solutionPath);
-    }
+    ValueTask<Solution> ReadSolutionAsync(string solutionPath);
 }

--- a/src/DotNet.IO/Solution/SolutionFileReader.cs
+++ b/src/DotNet.IO/Solution/SolutionFileReader.cs
@@ -1,60 +1,53 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using DotNet.Models;
-using SystemFile = System.IO.File;
+namespace DotNet.IO;
 
-namespace DotNet.IO
+public class SolutionFileReader : ISolutionFileReader
 {
-    public class SolutionFileReader : ISolutionFileReader
+    static readonly RegexOptions _options =
+        RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.ExplicitCapture;
+    static readonly Regex _solutionProjectsExpression =
+        new("^Project\\(\"{(?<TypeId>[A-F0-9-]+)}\"\\) = " +
+            "\"(?<Name>.*?)\", " +
+            "\"(?<Path>.*?)\", " +
+            "\"{(?<Id>[A-F0-9-]+)}\"" +
+            @"(?<Sections>(.|\n|\r)*?)" +
+            @"EndProject(\n|\r)",
+            _options);
+
+    readonly IProjectFileReader _projectFileReader;
+
+    public SolutionFileReader(IProjectFileReader projectFileReader) =>
+        _projectFileReader = projectFileReader;
+
+    public async ValueTask<Solution> ReadSolutionAsync(string solutionPath)
     {
-        static readonly RegexOptions _options =
-            RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.ExplicitCapture;
-        static readonly Regex _solutionProjectsExpression =
-            new("^Project\\(\"{(?<TypeId>[A-F0-9-]+)}\"\\) = " +
-                "\"(?<Name>.*?)\", " +
-                "\"(?<Path>.*?)\", " +
-                "\"{(?<Id>[A-F0-9-]+)}\"" +
-                @"(?<Sections>(.|\n|\r)*?)" +
-                @"EndProject(\n|\r)",
-                _options);
+        Solution solution = new();
 
-        readonly IProjectFileReader _projectFileReader;
-
-        public SolutionFileReader(IProjectFileReader projectFileReader) =>
-            _projectFileReader = projectFileReader;
-
-        public async ValueTask<Solution> ReadSolutionAsync(string solutionPath)
+        if (SystemFile.Exists(solutionPath))
         {
-            Solution solution = new();
+            solution.FullPath = Path.GetFullPath(solutionPath);
+            var solutionDirectory = Path.GetDirectoryName(solution.FullPath);
+            var solutionText = await SystemFile.ReadAllTextAsync(solution.FullPath);
+            var matches = _solutionProjectsExpression.Matches(solutionText);
 
-            if (SystemFile.Exists(solutionPath))
+            foreach (Match match in matches)
             {
-                solution.FullPath = Path.GetFullPath(solutionPath);
-                var solutionDirectory = Path.GetDirectoryName(solution.FullPath);
-                var solutionText = await SystemFile.ReadAllTextAsync(solution.FullPath);
-                var matches = _solutionProjectsExpression.Matches(solutionText);
+                var path = match.Groups["Path"].Value;
+                var fullPath = Path.Combine(solutionDirectory!, path);
 
-                foreach (Match match in matches)
+                if (SystemFile.Exists(fullPath) is false ||
+                    SystemFile.GetAttributes(fullPath).HasFlag(FileAttributes.Directory))
                 {
-                    var path = match.Groups["Path"].Value;
-                    var fullPath = Path.Combine(solutionDirectory!, path);
-
-                    if (SystemFile.Exists(fullPath) is false ||
-                        SystemFile.GetAttributes(fullPath).HasFlag(FileAttributes.Directory))
-                    {
-                        continue;
-                    }
-
-                    var project = await _projectFileReader.ReadProjectAsync(fullPath);
-                    solution.Projects.Add(project);
+                    continue;
                 }
-            }
 
-            return solution;
+                var project = await _projectFileReader.ReadProjectAsync(fullPath);
+                solution.Projects.Add(project);
+            }
         }
+
+        return solution;
     }
 }

--- a/src/DotNet.Models/DotNet.Models.csproj
+++ b/src/DotNet.Models/DotNet.Models.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/DotNet.Models/DotNet.Models.csproj
+++ b/src/DotNet.Models/DotNet.Models.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/DotNet.Models/FrameworkRelease.cs
+++ b/src/DotNet.Models/FrameworkRelease.cs
@@ -1,50 +1,44 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using DotNet.Extensions;
-using Microsoft.Deployment.DotNet.Releases;
+namespace DotNet.Models;
 
-namespace DotNet.Models
+public record FrameworkRelease(
+    string Version,
+    string Released,
+    string ReleaseNotesUrl,
+    string IncludedIn,
+    string EndOfLife,
+    FrameworkRuntime Runtime,
+    Developerpack DeveloperPack) : IRelease
 {
-    public record FrameworkRelease(
-        string Version,
-        string Released,
-        string ReleaseNotesUrl,
-        string IncludedIn,
-        string EndOfLife,
-        FrameworkRuntime Runtime,
-        Developerpack DeveloperPack) : IRelease
+    // https://docs.microsoft.com/dotnet/standard/frameworks#supported-target-frameworks
+    public string TargetFrameworkMoniker => Version.Split("-")[0] switch
     {
-        // https://docs.microsoft.com/dotnet/standard/frameworks#supported-target-frameworks
-        public string TargetFrameworkMoniker => Version.Split("-")[0] switch
-        {
-            "3.5.0" => "net35",
-            var version when version.StartsWith("v", StringComparison.OrdinalIgnoreCase) =>
-                $"net{version[1..].Replace(".", "")}",
-            var version when version.StartsWith("net", StringComparison.OrdinalIgnoreCase) =>
-                version.Replace(".", ""),
-            _ => $"net{Version.Split("-")[0].Replace(".", "")}"
-        };
+        "3.5.0" => "net35",
+        var version when version.StartsWith("v", StringComparison.OrdinalIgnoreCase) =>
+            $"net{version[1..].Replace(".", "")}",
+        var version when version.StartsWith("net", StringComparison.OrdinalIgnoreCase) =>
+            version.Replace(".", ""),
+        _ => $"net{Version.Split("-")[0].Replace(".", "")}"
+    };
 
-        public SupportPhase SupportPhase => EndOfLifeDate switch
-        {
-            var date when date is null && Version == "4.8" => SupportPhase.Current,
-            var date when date > DateTime.Now => SupportPhase.LTS,
+    public SupportPhase SupportPhase => EndOfLifeDate switch
+    {
+        var date when date is null && Version == "4.8" => SupportPhase.Current,
+        var date when date > DateTime.Now => SupportPhase.LTS,
 
-            _ => SupportPhase.EOL
-        };
+        _ => SupportPhase.EOL
+    };
 
-        public DateTime? EndOfLifeDate => EndOfLife.ToDateTime();
+    public DateTime? EndOfLifeDate => EndOfLife.ToDateTime();
 
-        public string ToBrandString() => $".NET Framework {TargetFrameworkMoniker}";
-    }
-
-    public record FrameworkRuntime(
-        string WebInstaller,
-        string OfflineInstaller,
-        Dictionary<string, string> LanguagePacks);
-
-    public record Developerpack(string OfflineInstaller);
+    public string ToBrandString() => $".NET Framework {TargetFrameworkMoniker}";
 }
+
+public record FrameworkRuntime(
+    string WebInstaller,
+    string OfflineInstaller,
+    Dictionary<string, string> LanguagePacks);
+
+public record Developerpack(string OfflineInstaller);

--- a/src/DotNet.Models/GlobalUsings.cs
+++ b/src/DotNet.Models/GlobalUsings.cs
@@ -1,11 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DotNet.VersionSweeper;
-
-public enum ActionType
-{
-    CreateIssue,
-    PullRequest,
-    DryRun
-}
+global using DotNet.Extensions;
+global using Microsoft.Deployment.DotNet.Releases;
+global using SystemPath = System.IO.Path;

--- a/src/DotNet.Models/IRelease.cs
+++ b/src/DotNet.Models/IRelease.cs
@@ -1,18 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Microsoft.Deployment.DotNet.Releases;
+namespace DotNet.Models;
 
-namespace DotNet.Models
+public interface IRelease
 {
-    public interface IRelease
-    {
-        string TargetFrameworkMoniker { get; }
-        SupportPhase SupportPhase { get; }
-        DateTime? EndOfLifeDate { get; }
-        string ReleaseNotesUrl { get; }
+    string TargetFrameworkMoniker { get; }
+    SupportPhase SupportPhase { get; }
+    DateTime? EndOfLifeDate { get; }
+    string ReleaseNotesUrl { get; }
 
-        string ToBrandString();
-    }
+    string ToBrandString();
 }

--- a/src/DotNet.Models/Project.cs
+++ b/src/DotNet.Models/Project.cs
@@ -1,61 +1,57 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using SystemPath = System.IO.Path;
+namespace DotNet.Models;
 
-namespace DotNet.Models
+public record Project
 {
-    public record Project
+    string _fullPath = null!;
+
+    /// <summary>
+    /// The SDK value that the project is specifying.
+    /// </summary>
+    public string? Sdk { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the project is the new SDK-style format.
+    /// </summary>
+    public bool IsSdkStyle => Sdk is not null and { Length: > 0 };
+
+    /// <summary>
+    /// The fully qualified path of the project.
+    /// </summary>
+    public string FullPath
     {
-        string _fullPath = null!;
-
-        /// <summary>
-        /// The SDK value that the project is specifying.
-        /// </summary>
-        public string? Sdk { get; init; }
-
-        /// <summary>
-        /// Gets a value indicating whether the project is the new SDK-style format.
-        /// </summary>
-        public bool IsSdkStyle => Sdk is not null and { Length: > 0 };
-
-        /// <summary>
-        /// The fully qualified path of the project.
-        /// </summary>
-        public string FullPath
+        get => _fullPath;
+        set
         {
-            get => _fullPath;
-            set
+            _fullPath = value;
+            if (value is { Length: > 0 })
             {
-                _fullPath = value;
-                if (value is { Length: > 0 })
-                {
-                    Extension = SystemPath.GetExtension(value);
-                }
+                Extension = SystemPath.GetExtension(value);
             }
         }
-
-        /// <summary>
-        /// The file extension of the project, for example; ".csproj".
-        /// </summary>
-        public string Extension { get; private set; } = null!;
-
-        /// <summary>
-        /// The line number in the project file where the TargetFramework(s) element exists.
-        /// </summary>
-        public int TfmLineNumber { get; init; } = -1;
-
-        /// <summary>
-        /// The raw string representation of the TargetFramework(s) element in the project file.
-        /// </summary>
-        public string RawTargetFrameworkMonikers { get; init; } = null!;
-
-        /// <summary>
-        /// The parsed target framework monikers.
-        /// </summary>
-        public string[] Tfms =>
-            RawTargetFrameworkMonikers?.Split(";", StringSplitOptions.RemoveEmptyEntries) ??
-            Array.Empty<string>();
     }
+
+    /// <summary>
+    /// The file extension of the project, for example; ".csproj".
+    /// </summary>
+    public string Extension { get; private set; } = null!;
+
+    /// <summary>
+    /// The line number in the project file where the TargetFramework(s) element exists.
+    /// </summary>
+    public int TfmLineNumber { get; init; } = -1;
+
+    /// <summary>
+    /// The raw string representation of the TargetFramework(s) element in the project file.
+    /// </summary>
+    public string RawTargetFrameworkMonikers { get; init; } = null!;
+
+    /// <summary>
+    /// The parsed target framework monikers.
+    /// </summary>
+    public string[] Tfms =>
+        RawTargetFrameworkMonikers?.Split(";", StringSplitOptions.RemoveEmptyEntries) ??
+        Array.Empty<string>();
 }

--- a/src/DotNet.Models/ProjectSupportReport.cs
+++ b/src/DotNet.Models/ProjectSupportReport.cs
@@ -1,20 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
+namespace DotNet.Models;
 
-namespace DotNet.Models
+public record ProjectSupportReport(
+    Project Project,
+    HashSet<TargetFrameworkMonikerSupport> TargetFrameworkMonikerSupports);
+
+public record TargetFrameworkMonikerSupport(
+    string TargetFrameworkMoniker,
+    string Version,
+    bool IsUnsupported,
+    IRelease Release)
 {
-    public record ProjectSupportReport(
-        Project Project,
-        HashSet<TargetFrameworkMonikerSupport> TargetFrameworkMonikerSupports);
-
-    public record TargetFrameworkMonikerSupport(
-        string TargetFrameworkMoniker,
-        string Version,
-        bool IsUnsupported,
-        IRelease Release)
-    {
-        public string NearestLtsVersion { get; set; } = null!;
-    }
+    public string NearestLtsVersion { get; set; } = null!;
 }

--- a/src/DotNet.Models/ReleaseFactory.cs
+++ b/src/DotNet.Models/ReleaseFactory.cs
@@ -1,38 +1,34 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Microsoft.Deployment.DotNet.Releases;
+namespace DotNet.Models;
 
-namespace DotNet.Models
+public class ReleaseFactory
 {
-    public class ReleaseFactory
-    {
-        public static IRelease Create<TSource>(
-            TSource source,
-            Func<TSource, string> toString,
-            string tfm, SupportPhase supportPhase,
-            DateTime? endOfLifeDate, string releaseNotesUrl) =>
-            new ReleaseWrapper<TSource>(() => toString(source))
-            {
-                TargetFrameworkMoniker = tfm,
-                SupportPhase = supportPhase,
-                EndOfLifeDate = endOfLifeDate,
-                ReleaseNotesUrl = releaseNotesUrl
-            };
-
-        private class ReleaseWrapper<TSource> : IRelease
+    public static IRelease Create<TSource>(
+        TSource source,
+        Func<TSource, string> toString,
+        string tfm, SupportPhase supportPhase,
+        DateTime? endOfLifeDate, string releaseNotesUrl) =>
+        new ReleaseWrapper<TSource>(() => toString(source))
         {
-            private readonly Func<string> _toString = null!;
+            TargetFrameworkMoniker = tfm,
+            SupportPhase = supportPhase,
+            EndOfLifeDate = endOfLifeDate,
+            ReleaseNotesUrl = releaseNotesUrl
+        };
 
-            public string TargetFrameworkMoniker { get; internal set; } = null!;
-            public SupportPhase SupportPhase { get; internal set; }
-            public DateTime? EndOfLifeDate { get; internal set; }
-            public string ReleaseNotesUrl { get; internal set; } = null!;
+    private class ReleaseWrapper<TSource> : IRelease
+    {
+        private readonly Func<string> _toString = null!;
 
-            internal ReleaseWrapper(Func<string> toString) => _toString = toString;
+        public string TargetFrameworkMoniker { get; internal set; } = null!;
+        public SupportPhase SupportPhase { get; internal set; }
+        public DateTime? EndOfLifeDate { get; internal set; }
+        public string ReleaseNotesUrl { get; internal set; } = null!;
 
-            public string ToBrandString() => _toString.Invoke();
-        }
+        internal ReleaseWrapper(Func<string> toString) => _toString = toString;
+
+        public string ToBrandString() => _toString.Invoke();
     }
 }

--- a/src/DotNet.Models/Solution.cs
+++ b/src/DotNet.Models/Solution.cs
@@ -1,14 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
+namespace DotNet.Models;
 
-namespace DotNet.Models
+public class Solution
 {
-    public class Solution
-    {
-        public string FullPath { get; set; } = null!;
+    public string FullPath { get; set; } = null!;
 
-        public HashSet<Project> Projects { get; } = new();
-    }
+    public HashSet<Project> Projects { get; } = new();
 }

--- a/src/DotNet.Models/SolutionSupportReport.cs
+++ b/src/DotNet.Models/SolutionSupportReport.cs
@@ -1,12 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
+namespace DotNet.Models;
 
-namespace DotNet.Models
+public record SolutionSupportReport(Solution Solution)
 {
-    public record SolutionSupportReport(Solution Solution)
-    {
-        public HashSet<ProjectSupportReport> ProjectSupportReports { get; } = new();
-    }
+    public HashSet<ProjectSupportReport> ProjectSupportReports { get; } = new();
 }

--- a/src/DotNet.Releases/Core/ICoreReleaseIndexService.cs
+++ b/src/DotNet.Releases/Core/ICoreReleaseIndexService.cs
@@ -1,27 +1,21 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Deployment.DotNet.Releases;
+namespace DotNet.Releases;
 
-namespace DotNet.Releases
+public interface ICoreReleaseIndexService
 {
-    public interface ICoreReleaseIndexService
+    Task<IReadOnlyDictionary<Product, IReadOnlyCollection<ProductRelease>>> GetReleasesAsync();
+
+    async ValueTask<Product?> GetNextLtsVersionAsync(string releaseVersion)
     {
-        Task<IReadOnlyDictionary<Product, IReadOnlyCollection<ProductRelease>>> GetReleasesAsync();
+        var version = new ReleaseVersion(releaseVersion);
+        var products = await GetReleasesAsync();
 
-        async ValueTask<Product?> GetNextLtsVersionAsync(string releaseVersion)
-        {
-            var version = new ReleaseVersion(releaseVersion);
-            var products = await GetReleasesAsync();
-
-            return products?.SelectMany(kvp => kvp.Value)
-                .Where(release => release.Version > version && !release.Product.IsOutOfSupport())
-                .OrderBy(_ => _.Version)
-                .Select(_ => _.Product)
-                .FirstOrDefault();
-        }
+        return products?.SelectMany(kvp => kvp.Value)
+            .Where(release => release.Version > version && !release.Product.IsOutOfSupport())
+            .OrderBy(_ => _.Version)
+            .Select(_ => _.Product)
+            .FirstOrDefault();
     }
 }

--- a/src/DotNet.Releases/DotNet.Releases.csproj
+++ b/src/DotNet.Releases/DotNet.Releases.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/DotNet.Releases/DotNet.Releases.csproj
+++ b/src/DotNet.Releases/DotNet.Releases.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -41,10 +41,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" Version="1.0.0-preview1.1.21116.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotNet.Releases/Extensions/DateTimeExtensions.cs
+++ b/src/DotNet.Releases/Extensions/DateTimeExtensions.cs
@@ -1,13 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
+namespace DotNet.Releases.Extensions;
 
-namespace DotNet.Releases.Extensions
+internal static class DateTimeExtensions
 {
-    internal static class DateTimeExtensions
-    {
-        internal static bool IsInTheFuture(this DateTime dateTime) =>
-            dateTime > DateTime.Now;
-    }
+    internal static bool IsInTheFuture(this DateTime dateTime) =>
+        dateTime > DateTime.Now;
 }

--- a/src/DotNet.Releases/Extensions/ProductExtensions.cs
+++ b/src/DotNet.Releases/Extensions/ProductExtensions.cs
@@ -1,20 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Deployment.DotNet.Releases;
+namespace DotNet.Releases.Extensions;
 
-namespace DotNet.Releases.Extensions
+public static class ProductExtensions
 {
-    public static class ProductExtensions
-    {
-        public static string GetTargetFrameworkMoniker(this Product product) =>
-            product is not null
-                ? product.ProductName switch
-                {
-                    ".NET" => $"net{product.ProductVersion}",
-                    ".NET Core" => $"netcoreapp{product.ProductVersion}",
-                    _ => product.ProductVersion
-                }
-                : string.Empty;
-    }
+    public static string GetTargetFrameworkMoniker(this Product product) =>
+        product is not null
+            ? product.ProductName switch
+            {
+                ".NET" => $"net{product.ProductVersion}",
+                ".NET Core" => $"netcoreapp{product.ProductVersion}",
+                _ => product.ProductVersion
+            }
+            : string.Empty;
 }

--- a/src/DotNet.Releases/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DotNet.Releases/Extensions/ServiceCollectionExtensions.cs
@@ -1,19 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using DotNet.Releases;
+namespace Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.Extensions.DependencyInjection
+public static class ServiceCollectionExtensions
 {
-    public static class ServiceCollectionExtensions
-    {
-        public static IServiceCollection AddDotNetReleaseServices(
-            this IServiceCollection services) =>
-            services
-                .AddMemoryCache()
-                .AddSingleton<ICoreReleaseIndexService, CoreReleaseIndexService>()
-                .AddSingleton<IFrameworkReleaseIndexService, FrameworkReleaseIndexService>()
-                .AddSingleton<IFrameworkReleaseService, FrameworkReleaseService>()
-                .AddSingleton<IUnsupportedProjectReporter, UnsupportedProjectReporter>();
-    }
+    public static IServiceCollection AddDotNetReleaseServices(
+        this IServiceCollection services) =>
+        services
+            .AddMemoryCache()
+            .AddSingleton<ICoreReleaseIndexService, CoreReleaseIndexService>()
+            .AddSingleton<IFrameworkReleaseIndexService, FrameworkReleaseIndexService>()
+            .AddSingleton<IFrameworkReleaseService, FrameworkReleaseService>()
+            .AddSingleton<IUnsupportedProjectReporter, UnsupportedProjectReporter>();
 }

--- a/src/DotNet.Releases/Framework/FrameworkReleaseIndexService.cs
+++ b/src/DotNet.Releases/Framework/FrameworkReleaseIndexService.cs
@@ -1,29 +1,26 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
+namespace DotNet.Releases;
 
-namespace DotNet.Releases
+public class FrameworkReleaseIndexService : IFrameworkReleaseIndexService
 {
-    public class FrameworkReleaseIndexService : IFrameworkReleaseIndexService
+    /// <summary>
+    /// Private sourhttps://github.com/dotnet/website-resources/tree/master/data/dotnet-framework-releases
+    /// </summary>
+    public HashSet<string> FrameworkReseaseFileNames { get; } = new()
     {
-        /// <summary>
-        /// Private sourhttps://github.com/dotnet/website-resources/tree/master/data/dotnet-framework-releases
-        /// </summary>
-        public HashSet<string> FrameworkReseaseFileNames { get; } = new()
-        {
-            "net35-sp1.json",
-            "net40.json",
-            "net45.json",
-            "net451.json",
-            "net452.json",
-            "net46.json",
-            "net461.json",
-            "net462.json",
-            "net47.json",
-            "net471.json",
-            "net472.json",
-            "net48.json"
-        };
-    }
+        "net35-sp1.json",
+        "net40.json",
+        "net45.json",
+        "net451.json",
+        "net452.json",
+        "net46.json",
+        "net461.json",
+        "net462.json",
+        "net47.json",
+        "net471.json",
+        "net472.json",
+        "net48.json"
+    };
 }

--- a/src/DotNet.Releases/Framework/IFrameworkReleaseIndexService.cs
+++ b/src/DotNet.Releases/Framework/IFrameworkReleaseIndexService.cs
@@ -1,12 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
+namespace DotNet.Releases;
 
-namespace DotNet.Releases
+public interface IFrameworkReleaseIndexService
 {
-    public interface IFrameworkReleaseIndexService
-    {
-        HashSet<string> FrameworkReseaseFileNames { get; }
-    }
+    HashSet<string> FrameworkReseaseFileNames { get; }
 }

--- a/src/DotNet.Releases/Framework/IFrameworkReleaseService.cs
+++ b/src/DotNet.Releases/Framework/IFrameworkReleaseService.cs
@@ -1,37 +1,29 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using DotNet.Models;
-using Microsoft.Deployment.DotNet.Releases;
+namespace DotNet.Releases;
 
-namespace DotNet.Releases
+public interface IFrameworkReleaseService
 {
-    public interface IFrameworkReleaseService
+    IAsyncEnumerable<FrameworkRelease> GetAllReleasesAsync();
+
+    async ValueTask<FrameworkRelease?> GetNextLtsVersionAsync(LabeledVersion releaseVersion)
     {
-        IAsyncEnumerable<FrameworkRelease> GetAllReleasesAsync();
+        var sequence = GetAllReleasesAsync();
+        var releases = await sequence.ToListAsync();
 
-        async ValueTask<FrameworkRelease?> GetNextLtsVersionAsync(LabeledVersion releaseVersion)
-        {
-            var sequence = GetAllReleasesAsync();
-            var releases = await sequence.ToListAsync();
+        static bool IsOutOfSupport(FrameworkRelease release) =>
+            release.SupportPhase == SupportPhase.EOL || release.EndOfLifeDate?.Date <= DateTime.Now.Date;
 
-            static bool IsOutOfSupport(FrameworkRelease release) =>
-                release.SupportPhase == SupportPhase.EOL || release.EndOfLifeDate?.Date <= DateTime.Now.Date;
+        var orderedReleases = releases?
+            .Where(release => release is not null)
+            .Select(release =>
+                (Version: (LabeledVersion)release!.Version, Release: release!))
+            .Where(_ =>
+                _.Version > releaseVersion && !IsOutOfSupport(_.Release))
+            .OrderBy(_ => _.Version);
 
-            var orderedReleases = releases?
-                .Where(release => release is not null)
-                .Select(release =>
-                    (Version: (LabeledVersion)release!.Version, Release: release!))
-                .Where(_ =>
-                    _.Version > releaseVersion && !IsOutOfSupport(_.Release))
-                .OrderBy(_ => _.Version);
-
-            return orderedReleases?.Select(_ => _.Release)
-                .FirstOrDefault();
-        }
+        return orderedReleases?.Select(_ => _.Release)
+            .FirstOrDefault();
     }
 }

--- a/src/DotNet.Releases/GlobalUsings.cs
+++ b/src/DotNet.Releases/GlobalUsings.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+global using System.Reflection;
+global using DotNet.Extensions;
+global using DotNet.Models;
+global using DotNet.Releases;
+global using DotNet.Releases.Extensions;
+global using Microsoft.Deployment.DotNet.Releases;
+global using Microsoft.Extensions.Caching.Memory;

--- a/src/DotNet.Releases/LabeledVersion.cs
+++ b/src/DotNet.Releases/LabeledVersion.cs
@@ -1,76 +1,73 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
+namespace DotNet.Releases;
 
-namespace DotNet.Releases
+public class LabeledVersion : IComparable<LabeledVersion?>
 {
-    public class LabeledVersion : IComparable<LabeledVersion?>
+    private readonly Version? _parsedVersion;
+
+    public int Build => _parsedVersion?.Build ?? 0;
+    public int Major => _parsedVersion?.Major ?? 0;
+    public short MajorRevision => _parsedVersion?.MajorRevision ?? 0;
+    public int Minor => _parsedVersion?.Minor ?? 0;
+    public short MinorRevision => _parsedVersion?.MinorRevision ?? 0;
+    public int Revision => _parsedVersion?.Revision ?? 0;
+    public string? Label { get; private set; }
+
+    private LabeledVersion() { }
+
+    public LabeledVersion(Version version, string? label = null) =>
+        (_parsedVersion, Label) = (version, label);
+
+    public static bool TryParse(string? input, out LabeledVersion? labeledVersion)
     {
-        private readonly Version? _parsedVersion;
-
-        public int Build => _parsedVersion?.Build ?? 0;
-        public int Major => _parsedVersion?.Major ?? 0;
-        public short MajorRevision => _parsedVersion?.MajorRevision ?? 0;
-        public int Minor => _parsedVersion?.Minor ?? 0;
-        public short MinorRevision => _parsedVersion?.MinorRevision ?? 0;
-        public int Revision => _parsedVersion?.Revision ?? 0;
-        public string? Label { get; private set; }
-
-        private LabeledVersion() { }
-
-        public LabeledVersion(Version version, string? label = null) =>
-            (_parsedVersion, Label) = (version, label);
-
-        public static bool TryParse(string? input, out LabeledVersion? labeledVersion)
+        if (input is not null and { Length: > 0 })
         {
-            if (input is not null and { Length: > 0 })
+            var split = input.Split("-");
+            if (Version.TryParse(split[0], out var version))
             {
-                var split = input.Split("-");
-                if (Version.TryParse(split[0], out var version))
-                {
-                    labeledVersion = new LabeledVersion(version, split.Length > 1 ? split[1] : null);
-                    return true;
-                }
+                labeledVersion = new LabeledVersion(version, split.Length > 1 ? split[1] : null);
+                return true;
             }
-
-            labeledVersion = null;
-            return false;
         }
 
-        public static implicit operator LabeledVersion(string input) =>
-            TryParse(input, out var version) ? version ?? new() : new();
-
-        public static bool operator ==(LabeledVersion? v1, LabeledVersion? v2) =>
-            v1?._parsedVersion == v2?._parsedVersion;
-
-        public static bool operator >(LabeledVersion? v1, LabeledVersion? v2) =>
-            v1?._parsedVersion > v2?._parsedVersion;
-
-        public static bool operator >=(LabeledVersion? v1, LabeledVersion? v2) =>
-            v1?._parsedVersion >= v2?._parsedVersion;
-
-        public static bool operator !=(LabeledVersion? v1, LabeledVersion? v2) =>
-            v1?._parsedVersion != v2?._parsedVersion;
-
-        public static bool operator <(LabeledVersion? v1, LabeledVersion? v2) =>
-            v1?._parsedVersion < v2?._parsedVersion;
-
-        public static bool operator <=(LabeledVersion? v1, LabeledVersion? v2) =>
-            v1?._parsedVersion <= v2?._parsedVersion;
-
-        int IComparable<LabeledVersion?>.CompareTo(LabeledVersion? other) =>
-            _parsedVersion?.CompareTo(other?._parsedVersion) ?? 0 +
-            Label?.CompareTo(other?.Label) ?? 0;
-
-        public override bool Equals(object? obj) =>
-            ReferenceEquals(this, obj)
-            || obj is not null
-            && obj is LabeledVersion other
-            && _parsedVersion == other._parsedVersion
-            && Label == other.Label;
-
-        public override int GetHashCode() =>
-            _parsedVersion?.GetHashCode() ?? 0 + Label?.GetHashCode() ?? 0;
+        labeledVersion = null;
+        return false;
     }
+
+    public static implicit operator LabeledVersion(string input) =>
+        TryParse(input, out var version) ? version ?? new() : new();
+
+    public static bool operator ==(LabeledVersion? v1, LabeledVersion? v2) =>
+        v1?._parsedVersion == v2?._parsedVersion;
+
+    public static bool operator >(LabeledVersion? v1, LabeledVersion? v2) =>
+        v1?._parsedVersion > v2?._parsedVersion;
+
+    public static bool operator >=(LabeledVersion? v1, LabeledVersion? v2) =>
+        v1?._parsedVersion >= v2?._parsedVersion;
+
+    public static bool operator !=(LabeledVersion? v1, LabeledVersion? v2) =>
+        v1?._parsedVersion != v2?._parsedVersion;
+
+    public static bool operator <(LabeledVersion? v1, LabeledVersion? v2) =>
+        v1?._parsedVersion < v2?._parsedVersion;
+
+    public static bool operator <=(LabeledVersion? v1, LabeledVersion? v2) =>
+        v1?._parsedVersion <= v2?._parsedVersion;
+
+    int IComparable<LabeledVersion?>.CompareTo(LabeledVersion? other) =>
+        _parsedVersion?.CompareTo(other?._parsedVersion) ?? 0 +
+        Label?.CompareTo(other?.Label) ?? 0;
+
+    public override bool Equals(object? obj) =>
+        ReferenceEquals(this, obj)
+        || obj is not null
+        && obj is LabeledVersion other
+        && _parsedVersion == other._parsedVersion
+        && Label == other.Label;
+
+    public override int GetHashCode() =>
+        _parsedVersion?.GetHashCode() ?? 0 + Label?.GetHashCode() ?? 0;
 }

--- a/src/DotNet.Releases/Reporting/IUnsupportedProjectReporter.cs
+++ b/src/DotNet.Releases/Reporting/IUnsupportedProjectReporter.cs
@@ -1,13 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using DotNet.Models;
+namespace DotNet.Releases;
 
-namespace DotNet.Releases
+public interface IUnsupportedProjectReporter
 {
-    public interface IUnsupportedProjectReporter
-    {
-        IAsyncEnumerable<ProjectSupportReport> ReportAsync(Project project, int outOfSupportWithinDays);
-    }
+    IAsyncEnumerable<ProjectSupportReport> ReportAsync(Project project, int outOfSupportWithinDays);
 }

--- a/src/DotNet.Releases/Reporting/UnsupportedProjectReporter.cs
+++ b/src/DotNet.Releases/Reporting/UnsupportedProjectReporter.cs
@@ -1,154 +1,145 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using DotNet.Models;
-using DotNet.Releases.Extensions;
-using Microsoft.Deployment.DotNet.Releases;
+namespace DotNet.Releases;
 
-namespace DotNet.Releases
+internal class UnsupportedProjectReporter : IUnsupportedProjectReporter
 {
-    internal class UnsupportedProjectReporter : IUnsupportedProjectReporter
+    readonly ICoreReleaseIndexService _coreReleaseIndexService;
+    readonly IFrameworkReleaseService _frameworkReleaseService;
+
+    public UnsupportedProjectReporter(
+        ICoreReleaseIndexService coreReleaseIndexService,
+        IFrameworkReleaseService frameworkReleaseService) =>
+        (_coreReleaseIndexService, _frameworkReleaseService) =
+            (coreReleaseIndexService, frameworkReleaseService);
+
+    async IAsyncEnumerable<ProjectSupportReport> IUnsupportedProjectReporter.ReportAsync(
+        Project project, int outOfSupportWithinDays)
     {
-        readonly ICoreReleaseIndexService _coreReleaseIndexService;
-        readonly IFrameworkReleaseService _frameworkReleaseService;
+        HashSet<TargetFrameworkMonikerSupport> resultingSupports = new();
+        DateTime outOfSupportWithinDate = DateTime.Now.Date.AddDays(outOfSupportWithinDays);
 
-        public UnsupportedProjectReporter(
-            ICoreReleaseIndexService coreReleaseIndexService,
-            IFrameworkReleaseService frameworkReleaseService) =>
-            (_coreReleaseIndexService, _frameworkReleaseService) =
-                (coreReleaseIndexService, frameworkReleaseService);
-
-        async IAsyncEnumerable<ProjectSupportReport> IUnsupportedProjectReporter.ReportAsync(
-            Project project, int outOfSupportWithinDays)
+        var products = await _coreReleaseIndexService.GetReleasesAsync();
+        foreach (var product in products.Keys)
         {
-            HashSet<TargetFrameworkMonikerSupport> resultingSupports = new();
-            DateTime outOfSupportWithinDate = DateTime.Now.Date.AddDays(outOfSupportWithinDays);
+            var tfmSupports =
+                project.Tfms.Select(
+                    tfm => TryEvaluateReleaseSupport(
+                        tfm, product.ProductVersion,
+                        product, outOfSupportWithinDate, out var tfmSupport)
+                            ? tfmSupport : null)
+                    .Where(tfmSupport => tfmSupport is not null);
 
-            var products = await _coreReleaseIndexService.GetReleasesAsync();
-            foreach (var product in products.Keys)
+            if (tfmSupports.Any())
             {
-                var tfmSupports =
-                    project.Tfms.Select(
-                        tfm => TryEvaluateReleaseSupport(
-                            tfm, product.ProductVersion,
-                            product, outOfSupportWithinDate, out var tfmSupport)
-                                ? tfmSupport : null)
-                        .Where(tfmSupport => tfmSupport is not null);
-
-                if (tfmSupports.Any())
-                {
-                    var supports = await Task.WhenAll(
-                        tfmSupports.Where(support => support?.IsUnsupported ?? false)
-                            .Select(
-                            async support =>
-                            {
-                                var release = await _coreReleaseIndexService.GetNextLtsVersionAsync(
-                                    product.LatestReleaseVersion.ToString());
-
-                                return support! with
-                                {
-                                    NearestLtsVersion = release!.GetTargetFrameworkMoniker()
-                                };
-                            }));
-
-                    foreach (var support in supports)
-                    {
-                        resultingSupports.Add(support);
-                    }
-                }
-            }
-
-            await foreach (var frameworkRelease
-                in _frameworkReleaseService.GetAllReleasesAsync())
-            {
-                var tfmSupports =
-                    project.Tfms.Select(
-                        tfm => TryEvaluateReleaseSupport(
-                            tfm, frameworkRelease!.Version,
-                            frameworkRelease, outOfSupportWithinDate, out var tfmSupport)
-                                ? tfmSupport : null)
-                        .Where(tfmSupport => tfmSupport is not null);
-
-                if (tfmSupports.Any())
-                {
-                    var supports = await Task.WhenAll(
-                        tfmSupports.Where(support => support?.IsUnsupported ?? false)
+                var supports = await Task.WhenAll(
+                    tfmSupports.Where(support => support?.IsUnsupported ?? false)
                         .Select(
-                            async support =>
+                        async support =>
+                        {
+                            var release = await _coreReleaseIndexService.GetNextLtsVersionAsync(
+                                product.LatestReleaseVersion.ToString());
+
+                            return support! with
                             {
-                                var release = await _frameworkReleaseService.GetNextLtsVersionAsync(
-                                    (LabeledVersion)frameworkRelease.Version);
+                                NearestLtsVersion = release!.GetTargetFrameworkMoniker()
+                            };
+                        }));
 
-                                return support! with
-                                {
-                                    NearestLtsVersion = release!.TargetFrameworkMoniker
-                                };
-                            }));
-
-                    foreach (var support in supports)
-                    {
-                        resultingSupports.Add(support);
-                    }
+                foreach (var support in supports)
+                {
+                    resultingSupports.Add(support);
                 }
             }
-
-            if (resultingSupports.Any())
-                yield return new(project, resultingSupports);
         }
 
-        static bool TryEvaluateReleaseSupport(
-            string tfm, string version,
-            Product product,
-            DateTime outOfSupportWithinDate,
-            out TargetFrameworkMonikerSupport? tfmSupport)
+        await foreach (var frameworkRelease
+            in _frameworkReleaseService.GetAllReleasesAsync())
         {
-            var release = ReleaseFactory.Create(
-                product,
-                pr => $"{pr.ProductName} {pr.ProductVersion}",
-                product.ProductName switch
+            var tfmSupports =
+                project.Tfms.Select(
+                    tfm => TryEvaluateReleaseSupport(
+                        tfm, frameworkRelease!.Version,
+                        frameworkRelease, outOfSupportWithinDate, out var tfmSupport)
+                            ? tfmSupport : null)
+                    .Where(tfmSupport => tfmSupport is not null);
+
+            if (tfmSupports.Any())
+            {
+                var supports = await Task.WhenAll(
+                    tfmSupports.Where(support => support?.IsUnsupported ?? false)
+                    .Select(
+                        async support =>
+                        {
+                            var release = await _frameworkReleaseService.GetNextLtsVersionAsync(
+                                (LabeledVersion)frameworkRelease.Version);
+
+                            return support! with
+                            {
+                                NearestLtsVersion = release!.TargetFrameworkMoniker
+                            };
+                        }));
+
+                foreach (var support in supports)
                 {
-                    ".NET" => $"net{product.ProductVersion}",
-                    ".NET Core" => $"netcoreapp{product.ProductVersion}",
-                    _ => product.ProductVersion
-                },
-                product.SupportPhase,
-                product.EndOfLifeDate,
-                product.ReleasesJson.ToString());
-
-            if (TargetFrameworkMonikerMap.RawMapsToKnown(tfm, release.TargetFrameworkMoniker))
-            {
-                var isOutOfSupport = product.IsOutOfSupport() ||
-                    product.EndOfLifeDate <= outOfSupportWithinDate;
-
-                tfmSupport = new(tfm, version, isOutOfSupport, release);
-                return true;
+                    resultingSupports.Add(support);
+                }
             }
-
-            tfmSupport = default;
-            return false;
         }
 
-        static bool TryEvaluateReleaseSupport(
-            string tfm, string version,
-            IRelease release,
-            DateTime outOfSupportWithinDate,
-            out TargetFrameworkMonikerSupport? tfmSupport)
+        if (resultingSupports.Any())
+            yield return new(project, resultingSupports);
+    }
+
+    static bool TryEvaluateReleaseSupport(
+        string tfm, string version,
+        Product product,
+        DateTime outOfSupportWithinDate,
+        out TargetFrameworkMonikerSupport? tfmSupport)
+    {
+        var release = ReleaseFactory.Create(
+            product,
+            pr => $"{pr.ProductName} {pr.ProductVersion}",
+            product.ProductName switch
+            {
+                ".NET" => $"net{product.ProductVersion}",
+                ".NET Core" => $"netcoreapp{product.ProductVersion}",
+                _ => product.ProductVersion
+            },
+            product.SupportPhase,
+            product.EndOfLifeDate,
+            product.ReleasesJson.ToString());
+
+        if (TargetFrameworkMonikerMap.RawMapsToKnown(tfm, release.TargetFrameworkMoniker))
         {
-            if (TargetFrameworkMonikerMap.RawMapsToKnown(tfm, release.TargetFrameworkMoniker))
-            {
-                var isOutOfSupport = release.SupportPhase == SupportPhase.EOL ||
-                    release.EndOfLifeDate?.Date <= outOfSupportWithinDate;
+            var isOutOfSupport = product.IsOutOfSupport() ||
+                product.EndOfLifeDate <= outOfSupportWithinDate;
 
-                tfmSupport = new(tfm, version, isOutOfSupport, release);
-                return true;
-            }
-
-            tfmSupport = default;
-            return false;
+            tfmSupport = new(tfm, version, isOutOfSupport, release);
+            return true;
         }
+
+        tfmSupport = default;
+        return false;
+    }
+
+    static bool TryEvaluateReleaseSupport(
+        string tfm, string version,
+        IRelease release,
+        DateTime outOfSupportWithinDate,
+        out TargetFrameworkMonikerSupport? tfmSupport)
+    {
+        if (TargetFrameworkMonikerMap.RawMapsToKnown(tfm, release.TargetFrameworkMoniker))
+        {
+            var isOutOfSupport = release.SupportPhase == SupportPhase.EOL ||
+                release.EndOfLifeDate?.Date <= outOfSupportWithinDate;
+
+            tfmSupport = new(tfm, version, isOutOfSupport, release);
+            return true;
+        }
+
+        tfmSupport = default;
+        return false;
     }
 }

--- a/src/DotNet.Releases/TargetFrameworkMonikerMap.cs
+++ b/src/DotNet.Releases/TargetFrameworkMonikerMap.cs
@@ -1,45 +1,40 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using DotNet.Extensions;
+namespace DotNet.Releases;
 
-namespace DotNet.Releases
+static class TargetFrameworkMonikerMap
 {
-    static class TargetFrameworkMonikerMap
-    {
-        static readonly Dictionary<string, string> _frameworkMonikers =
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["net11"] = "v1.1",
-                ["net20"] = "v2.0",
-                ["net35"] = "v3.5",
-                ["net40"] = "v4.0",
-                ["net403"] = "v4.0.3",
-                ["net45"] = "v4.5",
-                ["net451"] = "v4.5.1",
-                ["net452"] = "v4.5.2",
-                ["net46"] = "v4.6",
-                ["net461"] = "v4.6.1",
-                ["net462"] = "v4.6.2",
-                ["net47"] = "v4.7",
-                ["net471"] = "v4.7.1",
-                ["net472"] = "v4.7.2",
-                ["net48"] = "v4.8"
-            }.AsReverseMap();
-
-        static string StripAtHyphen(string tfm) => tfm?.Split("-")[0] ?? "";
-
-        internal static bool RawMapsToKnown(string parsedTfm, string knownTfm)
+    static readonly Dictionary<string, string> _frameworkMonikers =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            if (_frameworkMonikers.TryGetValue(StripAtHyphen(parsedTfm), out var tfm))
-            {
-                return string.Equals(knownTfm, tfm, StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(parsedTfm, knownTfm, StringComparison.OrdinalIgnoreCase);
-            }
+            ["net11"] = "v1.1",
+            ["net20"] = "v2.0",
+            ["net35"] = "v3.5",
+            ["net40"] = "v4.0",
+            ["net403"] = "v4.0.3",
+            ["net45"] = "v4.5",
+            ["net451"] = "v4.5.1",
+            ["net452"] = "v4.5.2",
+            ["net46"] = "v4.6",
+            ["net461"] = "v4.6.1",
+            ["net462"] = "v4.6.2",
+            ["net47"] = "v4.7",
+            ["net471"] = "v4.7.1",
+            ["net472"] = "v4.7.2",
+            ["net48"] = "v4.8"
+        }.AsReverseMap();
 
-            return string.Equals(parsedTfm, knownTfm, StringComparison.OrdinalIgnoreCase);
+    static string StripAtHyphen(string tfm) => tfm?.Split("-")[0] ?? "";
+
+    internal static bool RawMapsToKnown(string parsedTfm, string knownTfm)
+    {
+        if (_frameworkMonikers.TryGetValue(StripAtHyphen(parsedTfm), out var tfm))
+        {
+            return string.Equals(knownTfm, tfm, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(parsedTfm, knownTfm, StringComparison.OrdinalIgnoreCase);
         }
+
+        return string.Equals(parsedTfm, knownTfm, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/DotNet.Reporter/DotNet.Reporter.csproj
+++ b/src/DotNet.Reporter/DotNet.Reporter.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>version-reporter</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/src/DotNet.Reporter/DotNet.Reporter.csproj
+++ b/src/DotNet.Reporter/DotNet.Reporter.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>version-reporter</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotNet.Reporter/Program.cs
+++ b/src/DotNet.Reporter/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Linq;
 using DotNet.IO;
 using DotNet.Releases;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/DotNet.VersionSweeper/Discovery.cs
+++ b/src/DotNet.VersionSweeper/Discovery.cs
@@ -1,105 +1,92 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using DotNet.Extensions;
-using DotNet.GitHubActions;
-using DotNet.IO;
-using DotNet.Models;
-using Microsoft.Extensions.FileSystemGlobbing;
+namespace DotNet.VersionSweeper;
 
-namespace DotNet.VersionSweeper
+sealed class Discovery
 {
-    class Discovery
+    /// <summary>
+    /// Returns a list of solutions, each solution contains projects. Also returns a mapping
+    /// of orphaned projects that do not belong to solutions, but match the search patterns.
+    /// </summary>
+    internal static async Task<(ISet<Solution> Solutions, ISet<ModelProject> OrphanedProjects, VersionSweeperConfig Config)>
+        FindSolutionsAndProjectsAsync(
+            IServiceProvider services,
+            IJobService job,
+            Options options)
     {
-        /// <summary>
-        /// Returns a list of solutions, each solution contains projects. Also returns a mapping
-        /// of orphaned projects that do not belong to solutions, but match the search patterns.
-        /// </summary>
-        internal static async Task<(ISet<Solution> Solutions, ISet<Project> OrphanedProjects, VersionSweeperConfig Config)>
-            FindSolutionsAndProjectsAsync(
-                IServiceProvider services,
-                IJobService job,
-                Options options)
-        {
-            var (solutionReader, projectReader) =
-                services.GetRequiredServices<ISolutionFileReader, IProjectFileReader>();
+        var (solutionReader, projectReader) =
+            services.GetRequiredServices<ISolutionFileReader, IProjectFileReader>();
 
-            var (directory, extensions) =
-                (options.ToDirectoryInfo(), options.AsFileExtensions());
+        var (directory, extensions) =
+            (options.ToDirectoryInfo(), options.AsFileExtensions());
 
-            ConcurrentBag<Solution> solutions = new();
-            ConcurrentBag<Project> projects = new();
+        ConcurrentBag<Solution> solutions = new();
+        ConcurrentBag<ModelProject> projects = new();
 
-            var config = await VersionSweeperConfig.ReadAsync(options.Directory, job);
+        var config = await VersionSweeperConfig.ReadAsync(options.Directory, job);
 
-            var solutionMatcher = new Matcher().AddInclude("**/*.sln");
-            var projectMatcher = options.AsGlobMatcher(config.Ignore);
+        var solutionMatcher = new Matcher().AddInclude("**/*.sln");
+        var projectMatcher = options.AsGlobMatcher(config.Ignore);
 
-            await Task.WhenAll(
-                projectMatcher.GetResultsInFullPath(options.Directory)
-                    .ForEachAsync(
-                        Environment.ProcessorCount,
-                        async path =>
+        await Task.WhenAll(
+            projectMatcher.GetResultsInFullPath(options.Directory)
+                .ForEachAsync(
+                    Environment.ProcessorCount,
+                    async path =>
+                    {
+                        var project = await projectReader.ReadProjectAsync(path);
+                        if (project is { TfmLineNumber: > -1 })
                         {
-                            var project = await projectReader.ReadProjectAsync(path);
-                            if (project is { TfmLineNumber: > -1 })
-                            {
-                                projects.Add(project);
-                                job.Info($"Parsed TFM(s): '{string.Join(", ", project.Tfms)}' on line {project.TfmLineNumber} in {path}.");
-                            }
-                        }),
-                solutionMatcher.GetResultsInFullPath(options.Directory)
-                    .ForEachAsync(
-                        Environment.ProcessorCount,
-                        async path =>
+                            projects.Add(project);
+                            job.Info($"Parsed TFM(s): '{string.Join(", ", project.Tfms)}' on line {project.TfmLineNumber} in {path}.");
+                        }
+                    }),
+            solutionMatcher.GetResultsInFullPath(options.Directory)
+                .ForEachAsync(
+                    Environment.ProcessorCount,
+                    async path =>
+                    {
+                        var solution = await solutionReader.ReadSolutionAsync(path);
+                        if (solution is not null && solution.Projects is not null)
                         {
-                            var solution = await solutionReader.ReadSolutionAsync(path);
-                            if (solution is not null && solution.Projects is not null)
-                            {
-                                var match = projectMatcher.Match(
-                                    options.Directory,
-                                    solution.Projects.Select(proj => proj.FullPath));
+                            var match = projectMatcher.Match(
+                                options.Directory,
+                                solution.Projects.Select(proj => proj.FullPath));
 
-                                if (match.HasMatches)
+                            if (match.HasMatches)
+                            {
+                                var matchingProjects =
+                                    match.Files
+                                        .Select(f => Path.GetFullPath(Path.Combine(options.Directory, f.Path)))
+                                        .Distinct()
+                                        .ToHashSet();
+
+                                solution.Projects.RemoveWhere(
+                                    proj => !matchingProjects.Contains(proj.FullPath));
+
+                                if (solution.Projects.Count > 0)
                                 {
-                                    var matchingProjects =
-                                        match.Files
-                                            .Select(f => Path.GetFullPath(Path.Combine(options.Directory, f.Path)))
-                                            .Distinct()
-                                            .ToHashSet();
-
-                                    solution.Projects.RemoveWhere(
-                                        proj => !matchingProjects.Contains(proj.FullPath));
-
-                                    if (solution.Projects.Count > 0)
-                                    {
-                                        job.Info($"Read solution with {solution.Projects.Count} projects in it.");
-                                        solutions.Add(solution);
-                                    }
+                                    job.Info($"Read solution with {solution.Projects.Count} projects in it.");
+                                    solutions.Add(solution);
                                 }
                             }
-                        })
-                );
+                        }
+                    })
+            );
 
-            var solutionSet = solutions.ToHashSet();
-            var orphanedProjectSet =
-                projects.Except(solutions.SelectMany(sln => sln.Projects))
-                    .ToHashSet();
+        var solutionSet = solutions.ToHashSet();
+        var orphanedProjectSet =
+            projects.Except(solutions.SelectMany(sln => sln.Projects))
+                .ToHashSet();
 
-            job.Info($"Discovered {solutionSet.Count} solutions and {orphanedProjectSet.Count} orphaned projects.");
+        job.Info($"Discovered {solutionSet.Count} solutions and {orphanedProjectSet.Count} orphaned projects.");
 
-            return
-                (
-                    Solutions: solutionSet,
-                    OrphanedProjects: orphanedProjectSet,
-                    Config: config
-                );
-        }
+        return
+            (
+                Solutions: solutionSet,
+                OrphanedProjects: orphanedProjectSet,
+                Config: config
+            );
     }
 }

--- a/src/DotNet.VersionSweeper/DotNet.VersionSweeper.csproj
+++ b/src/DotNet.VersionSweeper/DotNet.VersionSweeper.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFile>true</GenerateRuntimeConfigurationFile>
     <Nullable>enable</Nullable>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotNet.VersionSweeper/DotNet.VersionSweeper.csproj
+++ b/src/DotNet.VersionSweeper/DotNet.VersionSweeper.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <GenerateRuntimeConfigurationFile>true</GenerateRuntimeConfigurationFile>
     <Nullable>enable</Nullable>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>

--- a/src/DotNet.VersionSweeper/EnvironmentVariableNames.cs
+++ b/src/DotNet.VersionSweeper/EnvironmentVariableNames.cs
@@ -1,22 +1,21 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DotNet.VersionSweeper
-{
-    public static class EnvironmentVariableNames
-    {
-        public static class GitHub
-        {
-            public const string Token = "GITHUB_TOKEN";
-        }
+namespace DotNet.VersionSweeper;
 
-        public static class Sweeper
-        {
-            public const string Owner = "OWNER";
-            public const string Name = "NAME";
-            public const string Branch = "BRANCH";
-            public const string Directory = "DIR";
-            public const string SearchPattern = "PATTERN";
-        }
+public static class EnvironmentVariableNames
+{
+    public static class GitHub
+    {
+        public const string Token = "GITHUB_TOKEN";
+    }
+
+    public static class Sweeper
+    {
+        public const string Owner = "OWNER";
+        public const string Name = "NAME";
+        public const string Branch = "BRANCH";
+        public const string Directory = "DIR";
+        public const string SearchPattern = "PATTERN";
     }
 }

--- a/src/DotNet.VersionSweeper/GlobalUsings.cs
+++ b/src/DotNet.VersionSweeper/GlobalUsings.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+global using System.Collections.Concurrent;
+global using System.Text;
+global using System.Text.Json.Serialization;
+global using CommandLine;
+global using DotNet.Extensions;
+global using DotNet.GitHub;
+global using DotNet.GitHubActions;
+global using DotNet.IO;
+global using DotNet.Models;
+global using DotNet.Releases;
+global using DotNet.VersionSweeper;
+global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.FileSystemGlobbing;
+global using Microsoft.Extensions.Hosting;
+global using Octokit;
+global using static System.Environment;
+global using static CommandLine.Parser;
+global using static DotNet.VersionSweeper.EnvironmentVariableNames;
+global using ModelProject = DotNet.Models.Project;

--- a/src/DotNet.VersionSweeper/Options.cs
+++ b/src/DotNet.VersionSweeper/Options.cs
@@ -1,87 +1,81 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using CommandLine;
-using static System.Environment;
-using static DotNet.VersionSweeper.EnvironmentVariableNames;
+namespace DotNet.VersionSweeper;
 
-namespace DotNet.VersionSweeper
+public class Options
 {
-    public class Options
+    string _repositoryName = null!;
+    string _branchName = null!;
+
+    public Options()
     {
-        string _repositoryName = null!;
-        string _branchName = null!;
+        Owner = GetEnvironmentVariable(Sweeper.Owner) ?? "";
+        Name = GetEnvironmentVariable(Sweeper.Name) ?? "";
+        Branch = GetEnvironmentVariable(Sweeper.Branch) ?? "";
+        Directory = GetEnvironmentVariable(Sweeper.Directory) ?? "";
+        SearchPattern = GetEnvironmentVariable(Sweeper.SearchPattern) ?? "";
+        Token = GetEnvironmentVariable(EnvironmentVariableNames.GitHub.Token) ?? "";
+    }
 
-        public Options()
+    [Option('o', "owner",
+        Required = true,
+        HelpText = "The owner, for example: \"dotnet\". " +
+        "Assign from `github.repository_owner`. " +
+        "Override with env var named `OWNER`.")]
+    public string Owner { get; set; }
+
+    [Option('n', "name",
+        Required = true,
+        HelpText = "The repository name, for example: \"samples\". " +
+        "Assign from `github.repository`. " +
+        "Override with env var named `NAME`.")]
+    public string Name
+    {
+        get => _repositoryName;
+        set => ParseAndAssign(value, str => _repositoryName = str);
+    }
+
+    [Option('b', "branch",
+        Required = true,
+        HelpText = "The branch name, for example: \"refs/heads/main\". " +
+        "Assign from `github.ref`. " +
+        "Override with env var named `BRANCH`.")]
+    public string Branch
+    {
+        get => _branchName;
+        set => ParseAndAssign(value, str => _branchName = str);
+    }
+
+    [Option('t', "token",
+        HelpText = "The GitHub personal-access token (PAT), or the token from GitHub action context. " +
+        "Assign from `github.token`." +
+        "Override with env var named `GITHUB_TOKEN`.`")]
+    public string Token { get; set; }
+
+    [Option('d', "dir",
+        Required = true,
+        HelpText = "The root directory to start recursive searching from." +
+        "Assign from `github.workspace`. " +
+        "Override with env var named `DIRECTORY`.")]
+    public string Directory { get; set; }
+
+    [Option('p', "pattern",
+        Required = true,
+        HelpText = "The search pattern to discover project files. " +
+        "Override with env var named `PATTERN`.")]
+    public string SearchPattern { get; set; }
+
+    [Option('s', "sdk-compliance",
+        HelpText = "Indicates whether or not to report projects that " +
+        "are not using the new SDK-style project format.")]
+    public bool ReportNonSdkStyleProjects { get; set; }
+
+    static void ParseAndAssign(string? value, Action<string> assign)
+    {
+        if (value is { Length: > 0 } && assign is not null)
         {
-            Owner = GetEnvironmentVariable(Sweeper.Owner) ?? "";
-            Name = GetEnvironmentVariable(Sweeper.Name) ?? "";
-            Branch = GetEnvironmentVariable(Sweeper.Branch) ?? "";
-            Directory = GetEnvironmentVariable(Sweeper.Directory) ?? "";
-            SearchPattern = GetEnvironmentVariable(Sweeper.SearchPattern) ?? "";
-            Token = GetEnvironmentVariable(EnvironmentVariableNames.GitHub.Token) ?? "";
-        }
-
-        [Option('o', "owner",
-            Required = true,
-            HelpText = "The owner, for example: \"dotnet\". " +
-            "Assign from `github.repository_owner`. " +
-            "Override with env var named `OWNER`.")]
-        public string Owner { get; set; }
-
-        [Option('n', "name",
-            Required = true,
-            HelpText = "The repository name, for example: \"samples\". " +
-            "Assign from `github.repository`. " +
-            "Override with env var named `NAME`.")]
-        public string Name
-        {
-            get => _repositoryName;
-            set => ParseAndAssign(value, str => _repositoryName = str);
-        }
-
-        [Option('b', "branch",
-            Required = true,
-            HelpText = "The branch name, for example: \"refs/heads/main\". " +
-            "Assign from `github.ref`. " +
-            "Override with env var named `BRANCH`.")]
-        public string Branch
-        {
-            get => _branchName;
-            set => ParseAndAssign(value, str => _branchName = str);
-        }
-
-        [Option('t', "token",
-            HelpText = "The GitHub personal-access token (PAT), or the token from GitHub action context. " +
-            "Assign from `github.token`." +
-            "Override with env var named `GITHUB_TOKEN`.`")]
-        public string Token { get; set; }
-
-        [Option('d', "dir",
-            Required = true,
-            HelpText = "The root directory to start recursive searching from." +
-            "Assign from `github.workspace`. " +
-            "Override with env var named `DIRECTORY`.")]
-        public string Directory { get; set; }
-
-        [Option('p', "pattern",
-            Required = true,
-            HelpText = "The search pattern to discover project files. " +
-            "Override with env var named `PATTERN`.")]
-        public string SearchPattern { get; set; }
-
-        [Option('s', "sdk-compliance",
-            HelpText = "Indicates whether or not to report projects that " +
-            "are not using the new SDK-style project format.")]
-        public bool ReportNonSdkStyleProjects { get; set; }
-
-        static void ParseAndAssign(string? value, Action<string> assign)
-        {
-            if (value is { Length: > 0 } && assign is not null)
-            {
-                assign(value.Split("/")[^1]);
-            }
+            assign(value.Split("/")[^1]);
         }
     }
 }

--- a/src/DotNet.VersionSweeper/OptionsExtensions.cs
+++ b/src/DotNet.VersionSweeper/OptionsExtensions.cs
@@ -1,74 +1,65 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using DotNet.GitHubActions;
-using Microsoft.Extensions.FileSystemGlobbing;
+namespace DotNet.VersionSweeper;
 
-namespace DotNet.VersionSweeper
+public static class OptionsExtensions
 {
-    public static class OptionsExtensions
+    public static Matcher AsGlobMatcher(this Options options, string[] ignoreGlobs)
     {
-        public static Matcher AsGlobMatcher(this Options options, string[] ignoreGlobs)
-        {
-            Matcher matcher = new();
+        Matcher matcher = new();
 
-            matcher.AddExcludePatterns(ignoreGlobs);
-            if (options.SearchPattern is not null)
+        matcher.AddExcludePatterns(ignoreGlobs);
+        if (options.SearchPattern is not null)
+        {
+            matcher.AddIncludePatterns(
+                options.SearchPattern
+                    .SplitOnExpectedDelimiters()
+                    .AsRecursivePatterns());
+        }
+
+        return matcher;
+    }
+
+    public static string[] SplitOnExpectedDelimiters(this string? searchPattern) =>
+        searchPattern is null or { Length: 0 }
+            ? Array.Empty<string>()
+            : (searchPattern.Contains(';'), searchPattern.Contains('|'), searchPattern.Contains(',')) switch
             {
-                matcher.AddIncludePatterns(
-                    options.SearchPattern
-                        .SplitOnExpectedDelimiters()
-                        .AsRecursivePatterns());
-            }
+                (true, _, _) => searchPattern.Split(';', StringSplitOptions.RemoveEmptyEntries),
+                (_, true, _) => searchPattern.Split('|', StringSplitOptions.RemoveEmptyEntries),
+                (_, _, true) => searchPattern.Split(',', StringSplitOptions.RemoveEmptyEntries),
 
-            return matcher;
-        }
+                _ => new string[] { searchPattern }
+            };
 
-        public static string[] SplitOnExpectedDelimiters(this string? searchPattern) =>
-            searchPattern is null or { Length: 0 }
-                ? Array.Empty<string>()
-                : (searchPattern.Contains(';'), searchPattern.Contains('|'), searchPattern.Contains(',')) switch
-                {
-                    (true, _, _) => searchPattern.Split(';', StringSplitOptions.RemoveEmptyEntries),
-                    (_, true, _) => searchPattern.Split('|', StringSplitOptions.RemoveEmptyEntries),
-                    (_, _, true) => searchPattern.Split(',', StringSplitOptions.RemoveEmptyEntries),
+    public static IEnumerable<string> AsRecursivePatterns(this string[] patterns) =>
+        patterns.Select(pattern => $"**/{pattern}");
 
-                    _ => new string[] { searchPattern }
-                };
+    public static HashSet<string> AsFileExtensions(this Options options) =>
+        options.SearchPattern
+            .SplitOnExpectedDelimiters()
+            .Select(Path.GetExtension)
+            .Where(ext => ext is not null)
+            .Select(ext => ext!)
+            .ToHashSet();
 
-        public static IEnumerable<string> AsRecursivePatterns(this string[] patterns) =>
-            patterns.Select(pattern => $"**/{pattern}");
+    public static DirectoryInfo ToDirectoryInfo(this Options options) => new(options.Directory);
 
-        public static HashSet<string> AsFileExtensions(this Options options) =>
-            options.SearchPattern
-                .SplitOnExpectedDelimiters()
-                .Select(Path.GetExtension)
-                .Where(ext => ext is not null)
-                .Select(ext => ext!)
-                .ToHashSet();
+    public static void WriteDebugInfo(this Options options, IJobService job)
+    {
+        job.SetCommandEcho(true);
 
-        public static DirectoryInfo ToDirectoryInfo(this Options options) => new(options.Directory);
+        StringBuilder builder = new();
+        builder.AppendLine($"repository owner: {options.Owner}");
+        builder.AppendLine($"repository name: {options.Name}");
+        builder.AppendLine($"current branch: {options.Branch}");
+        builder.AppendLine($"root directory to search: {options.Directory}");
+        var parsedPatterns = string.Join(", ",
+            options.SearchPattern?.SplitOnExpectedDelimiters().AsRecursivePatterns() ?? Array.Empty<string>());
+        builder.AppendLine($"parsed patterns: {parsedPatterns}");
+        builder.AppendLine($"report non-SDK style projects: {options.ReportNonSdkStyleProjects}");
 
-        public static void WriteDebugInfo(this Options options, IJobService job)
-        {
-            job.SetCommandEcho(true);
-
-            StringBuilder builder = new();
-            builder.AppendLine($"repository owner: {options.Owner}");
-            builder.AppendLine($"repository name: {options.Name}");
-            builder.AppendLine($"current branch: {options.Branch}");
-            builder.AppendLine($"root directory to search: {options.Directory}");
-            var parsedPatterns = string.Join(", ",
-                options.SearchPattern?.SplitOnExpectedDelimiters().AsRecursivePatterns() ?? Array.Empty<string>());
-            builder.AppendLine($"parsed patterns: {parsedPatterns}");
-            builder.AppendLine($"report non-SDK style projects: {options.ReportNonSdkStyleProjects}");
-
-            job.Info(builder.ToString());
-        }
+        job.Info(builder.ToString());
     }
 }

--- a/src/DotNet.VersionSweeper/Program.cs
+++ b/src/DotNet.VersionSweeper/Program.cs
@@ -1,22 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using CommandLine;
-using DotNet.GitHub;
-using DotNet.GitHubActions;
-using DotNet.Models;
-using DotNet.Releases;
-using DotNet.VersionSweeper;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Octokit;
-using static CommandLine.Parser;
-using Project = DotNet.Models.Project;
-
 using var host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((_, services) =>
         services.AddDotNetGitHubServices()
@@ -87,7 +71,7 @@ static async Task StartSweeperAsync(Options options, IServiceProvider services, 
             }
         }
 
-        HashSet<Project> nonSdkStyleProjects = new();
+        HashSet<ModelProject> nonSdkStyleProjects = new();
         Dictionary<string, HashSet<ProjectSupportReport>> tfmToProjectSupportReports =
             new(StringComparer.OrdinalIgnoreCase);
 

--- a/src/DotNet.VersionSweeper/ServiceProviderExtensions.cs
+++ b/src/DotNet.VersionSweeper/ServiceProviderExtensions.cs
@@ -1,31 +1,27 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Microsoft.Extensions.DependencyInjection;
+namespace DotNet.VersionSweeper;
 
-namespace DotNet.VersionSweeper
+public static class ServiceProviderExtensions
 {
-    public static class ServiceProviderExtensions
-    {
-        public static (T1, T2) GetRequiredServices<T1, T2>(
-            this IServiceProvider provider)
-            where T1 : notnull
-            where T2 : notnull =>
-            (
-                provider.GetRequiredService<T1>(),
-                provider.GetRequiredService<T2>()
-            );
+    public static (T1, T2) GetRequiredServices<T1, T2>(
+        this IServiceProvider provider)
+        where T1 : notnull
+        where T2 : notnull =>
+        (
+            provider.GetRequiredService<T1>(),
+            provider.GetRequiredService<T2>()
+        );
 
-        public static (T1, T2, T3) GetRequiredServices<T1, T2, T3>(
-            this IServiceProvider provider)
-            where T1 : notnull
-            where T2 : notnull
-            where T3 : notnull =>
-            (
-                provider.GetRequiredService<T1>(),
-                provider.GetRequiredService<T2>(),
-                provider.GetRequiredService<T3>()
-            );
-    }
+    public static (T1, T2, T3) GetRequiredServices<T1, T2, T3>(
+        this IServiceProvider provider)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull =>
+        (
+            provider.GetRequiredService<T1>(),
+            provider.GetRequiredService<T2>(),
+            provider.GetRequiredService<T3>()
+        );
 }

--- a/src/DotNet.VersionSweeper/VersionSweeperConfig.cs
+++ b/src/DotNet.VersionSweeper/VersionSweeperConfig.cs
@@ -1,70 +1,61 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
-using DotNet.Extensions;
-using DotNet.GitHubActions;
+namespace DotNet.VersionSweeper;
 
-namespace DotNet.VersionSweeper
+/// <summary>
+/// Example 'dotnet-versionsweeper.json' file:
+/// {
+///     "type": "pullRequest",
+///     "outOfSupportWithinDays": 90,
+///     "ignore": [
+///         "**/pinned-versions/**",
+///         "**/*.fsproj"
+///     ]
+/// }
+/// </summary>
+public class VersionSweeperConfig
 {
-    /// <summary>
-    /// Example 'dotnet-versionsweeper.json' file:
-    /// {
-    ///     "type": "pullRequest",
-    ///     "outOfSupportWithinDays": 90,
-    ///     "ignore": [
-    ///         "**/pinned-versions/**",
-    ///         "**/*.fsproj"
-    ///     ]
-    /// }
-    /// </summary>
-    public class VersionSweeperConfig
+    internal const string FileName = "dotnet-versionsweeper.json";
+
+    [JsonPropertyName("ignore")]
+    public string[] Ignore { get; init; } = Array.Empty<string>();
+
+    [JsonPropertyName("type")]
+    public ActionType Type { get; init; } = ActionType.CreateIssue;
+
+    [JsonPropertyName("outOfSupportWithinDays")]
+    public int OutOfSupportWithinDays { get; init; } = 0;
+
+    internal static async Task<VersionSweeperConfig> ReadAsync(string root, IJobService job)
     {
-        internal const string FileName = "dotnet-versionsweeper.json";
-
-        [JsonPropertyName("ignore")]
-        public string[] Ignore { get; init; } = Array.Empty<string>();
-
-        [JsonPropertyName("type")]
-        public ActionType Type { get; init; } = ActionType.CreateIssue;
-
-        [JsonPropertyName("outOfSupportWithinDays")]
-        public int OutOfSupportWithinDays { get; init; } = 0;
-
-        internal static async Task<VersionSweeperConfig> ReadAsync(string root, IJobService job)
+        try
         {
-            try
+            var fullPath = Path.Combine(root, FileName);
+            if (File.Exists(fullPath))
             {
-                var fullPath = Path.Combine(root, FileName);
-                if (File.Exists(fullPath))
-                {
-                    job.Info($"Reading '{fullPath}' config file.");
+                job.Info($"Reading '{fullPath}' config file.");
 
-                    var configJson = await File.ReadAllTextAsync(fullPath);
-                    var config = configJson.FromJson<VersionSweeperConfig>() ?? new();
+                var configJson = await File.ReadAllTextAsync(fullPath);
+                var config = configJson.FromJson<VersionSweeperConfig>() ?? new();
 
-                    job.Info($"Read {config.Ignore.Length} pattern(s) to ignore:");
-                    job.Info($"{string.Join(",", config.Ignore.Select(val => $"\t{val}"))}");
-                    job.Info($"Intended version sweeper type: {config.Type}");
-                    job.Info($"Out of support within days: {config.OutOfSupportWithinDays}");
+                job.Info($"Read {config.Ignore.Length} pattern(s) to ignore:");
+                job.Info($"{string.Join(",", config.Ignore.Select(val => $"\t{val}"))}");
+                job.Info($"Intended version sweeper type: {config.Type}");
+                job.Info($"Out of support within days: {config.OutOfSupportWithinDays}");
 
-                    return config;
-                }
-                else
-                {
-                    job.Info($"No '{fullPath}' config file to read.");
-                }
+                return config;
             }
-            catch
+            else
             {
-                job.Warning($"Unable to read '{FileName}'.");
+                job.Info($"No '{fullPath}' config file to read.");
             }
-
-            return new();
         }
+        catch
+        {
+            job.Warning($"Unable to read '{FileName}'.");
+        }
+
+        return new();
     }
 }

--- a/test/DotNet.ExtensionsTests/DotNet.ExtensionsTests.csproj
+++ b/test/DotNet.ExtensionsTests/DotNet.ExtensionsTests.csproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/DotNet.ExtensionsTests/DotNet.ExtensionsTests.csproj
+++ b/test/DotNet.ExtensionsTests/DotNet.ExtensionsTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/DotNet.ExtensionsTests/ObjectExtensionsTests.cs
+++ b/test/DotNet.ExtensionsTests/ObjectExtensionsTests.cs
@@ -1,17 +1,15 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Xunit;
 
-namespace DotNet.Extensions.Tests
+namespace DotNet.Extensions.Tests;
+
+public class ObjectExtensionsTests
 {
-    public class ObjectExtensionsTests
+    public static IEnumerable<object[]> FromJsonInput = new[]
     {
-        public static IEnumerable<object[]> FromJsonInput = new[]
-        {
             new object[]
             {
                 "{ \"value\": \"one\" }", new { Value = TestEnum.ButThisIsAlsoOne }
@@ -24,24 +22,24 @@ namespace DotNet.Extensions.Tests
             },
         };
 
-        [
-            Theory,
-            MemberData(nameof(FromJsonInput))
-        ]
-        public void FromJsonTest<T>(string json, T expected, Func<T, T, bool> customEqual = default)
+    [
+        Theory,
+        MemberData(nameof(FromJsonInput))
+    ]
+    public void FromJsonTest<T>(string json, T expected, Func<T, T, bool> customEqual = default)
+    {
+        if (customEqual is null)
         {
-            if (customEqual is null)
-            {
-                Assert.Equal(expected, json.FromJson<T>());
-            }
-            else
-            {
-                Assert.True(customEqual.Invoke(expected, json.FromJson<T>()));
-            }
+            Assert.Equal(expected, json.FromJson<T>());
         }
-
-        public static IEnumerable<object[]> ToJsonInput = new[]
+        else
         {
+            Assert.True(customEqual.Invoke(expected, json.FromJson<T>()));
+        }
+    }
+
+    public static IEnumerable<object[]> ToJsonInput = new[]
+    {
             new object[]
             {
                 new { Value = TestEnum.ButThisIsAlsoOne },
@@ -54,15 +52,15 @@ namespace DotNet.Extensions.Tests
             },
         };
 
-        [
-            Theory,
-            MemberData(nameof(ToJsonInput))
-        ]
-        public void ToJsonTest<T>(T value, string expected) =>
-            Assert.Equal(expected, value.ToJson(), true);
+    [
+        Theory,
+        MemberData(nameof(ToJsonInput))
+    ]
+    public void ToJsonTest<T>(T value, string expected) =>
+        Assert.Equal(expected, value.ToJson(), true);
 
-        public static IEnumerable<object[]> ToDateTimeInput = new[]
-        {
+    public static IEnumerable<object[]> ToDateTimeInput = new[]
+    {
             new object[] { "2021-01-12", new DateTime(2021, 1, 12) },
             new object[] { "2022-12-03", new DateTime(2022, 12, 3) },
             new object[] { "2019-02-12", new DateTime(2019, 2, 12) },
@@ -70,27 +68,26 @@ namespace DotNet.Extensions.Tests
             new object[] { "...", null },
         };
 
-        [
-            Theory,
-            MemberData(nameof(ToDateTimeInput))
-        ]
-        public void ToDateTime(string value, DateTime? expected) =>
-            Assert.Equal(expected, value.ToDateTime());
-    }
+    [
+        Theory,
+        MemberData(nameof(ToDateTimeInput))
+    ]
+    public void ToDateTime(string value, DateTime? expected) =>
+        Assert.Equal(expected, value.ToDateTime());
+}
 
-    enum TestEnum
-    {
-        Zero = 0,
+enum TestEnum
+{
+    Zero = 0,
 
-        One = 1,
-        ButThisIsAlsoOne = 1,
+    One = 1,
+    ButThisIsAlsoOne = 1,
 
-        Two = 2,
-        WaitWhat = 2
-    }
+    Two = 2,
+    WaitWhat = 2
+}
 
-    public class CustomName
-    {
-        [JsonPropertyName("test.value")] public string TestValue { get; init; }
-    }
+public class CustomName
+{
+    [JsonPropertyName("test.value")] public string TestValue { get; init; }
 }

--- a/test/DotNet.ExtensionsTests/StringExtensionsTests.cs
+++ b/test/DotNet.ExtensionsTests/StringExtensionsTests.cs
@@ -1,20 +1,19 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
 using Xunit;
 
-namespace DotNet.Extensions.Tests
+namespace DotNet.Extensions.Tests;
+
+public class StringExtensionsTests
 {
-    public class StringExtensionsTests
+    [Fact]
+    public void FirstAndLastSegementsOfPathTest()
     {
-        [Fact]
-        public void FirstAndLastSegementsOfPathTest()
-        {
-            var d = Path.DirectorySeparatorChar;
-            foreach (var (input, expected, limit)
-                in new[]
-                {
+        var d = Path.DirectorySeparatorChar;
+        foreach (var (input, expected, limit)
+            in new[]
+            {
                     (null, null, 10),
                     ($"path-project.csproj", "path-project.csproj", 20),
                     ($"example{d}of{d}some{d}path{d}project.csproj", "example/of/some/path/project.csproj", 40),
@@ -28,10 +27,9 @@ namespace DotNet.Extensions.Tests
                         "dapine/.../dotnet-api-docs/samples/snippets/xaml/VS_Snippets_Wpf/FrameNavigationUIVisibilitySnippets/XAML.csproj",
                         113
                     )
-                })
-            {
-                Assert.Equal(expected, input.ShrinkPath(limit: limit));
-            }
+            })
+        {
+            Assert.Equal(expected, input.ShrinkPath(limit: limit));
         }
     }
 }

--- a/test/DotNet.GitHubActionsTests/DotNet.GitHubActionsTests.csproj
+++ b/test/DotNet.GitHubActionsTests/DotNet.GitHubActionsTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/DotNet.GitHubActionsTests/DotNet.GitHubActionsTests.csproj
+++ b/test/DotNet.GitHubActionsTests/DotNet.GitHubActionsTests.csproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>.NETCoreApp,Version=v5.0</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/DotNet.GitHubActionsTests/JobServiceTests.cs
+++ b/test/DotNet.GitHubActionsTests/JobServiceTests.cs
@@ -1,20 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using DotNet.GitHubActions;
 using Xunit;
 
-namespace DotNet.GitHubActionsTests
-{
-    public sealed class JobServiceTests : IDisposable
-    {
-        static readonly TextWriter s_consoleOut = Console.Out;
+namespace DotNet.GitHubActionsTests;
 
-        public static IEnumerable<object[]> WriteSaveStateInput = new[]
-        {
+public sealed class JobServiceTests : IDisposable
+{
+    static readonly TextWriter s_consoleOut = Console.Out;
+
+    public static IEnumerable<object[]> WriteSaveStateInput = new[]
+    {
             new object[]
             {
                 "test-state",
@@ -35,27 +32,27 @@ namespace DotNet.GitHubActionsTests
             }
         };
 
-        [
-            Theory,
-            MemberData(nameof(WriteSaveStateInput))
-        ]
-        public void WriteSaveStateCommandTest<T>(
-            string stateName,
-            T stateValue,
-            string[] expectedCommands)
-        {
-            var interceptor = InterceptOut();
-            IJobService sut = new JobService();
+    [
+        Theory,
+        MemberData(nameof(WriteSaveStateInput))
+    ]
+    public void WriteSaveStateCommandTest<T>(
+        string stateName,
+        T stateValue,
+        string[] expectedCommands)
+    {
+        var interceptor = InterceptOut();
+        IJobService sut = new JobService();
 
-            sut.SaveState(stateName, stateValue);
+        sut.SaveState(stateName, stateValue);
 
-            AssertCommand(
-                interceptor,
-                expectedCommands);
-        }
+        AssertCommand(
+            interceptor,
+            expectedCommands);
+    }
 
-        public static IEnumerable<object[]> WriteSetOutputInput = new[]
-        {
+    public static IEnumerable<object[]> WriteSetOutputInput = new[]
+    {
             new object[]
             {
                 new Dictionary<string, string>
@@ -110,84 +107,83 @@ namespace DotNet.GitHubActionsTests
             }
         };
 
-        [
-            Theory,
-            MemberData(nameof(WriteSetOutputInput))
-        ]
-        public void WriteSetOutputCommandTest(
-            Dictionary<string, string> properties,
-            string message,
-            string[] expectedCommands)
-        {
-            var interceptor = InterceptOut();
-            IJobService sut = new JobService();
+    [
+        Theory,
+        MemberData(nameof(WriteSetOutputInput))
+    ]
+    public void WriteSetOutputCommandTest(
+        Dictionary<string, string> properties,
+        string message,
+        string[] expectedCommands)
+    {
+        var interceptor = InterceptOut();
+        IJobService sut = new JobService();
 
-            sut.SetOutput(message, properties);
+        sut.SetOutput(message, properties);
 
-            AssertCommand(
-                interceptor,
-                expectedCommands);
-        }
-
-        [Fact]
-        public void WriteWarningMessageTest()
-        {
-            var interceptor = InterceptOut();
-            IJobService sut = new JobService();
-            sut.Warning("Um, not sure....but something feels off!");
-
-            AssertCommand(
-                interceptor,
-                new[] { "::warning::Um, not sure....but something feels off!" });
-        }
-
-        [Fact]
-        public void WriteDebugMessageTest()
-        {
-            var interceptor = InterceptOut();
-            IJobService sut = new JobService();
-            sut.Debug("Does this really work?");
-
-            AssertCommand(
-                interceptor,
-                new[] { "::debug::Does this really work?" });
-        }
-
-        [Fact]
-        public void GroupMessagesTest()
-        {
-            var interceptor = InterceptOut();
-            IJobService sut = new JobService();
-            sut.StartGroup("example");
-            sut.Info("Testing... 1, 2, free?!");
-            sut.EndGroup();
-
-            AssertCommand(
-                interceptor,
-                new[] { "::group::example", "Testing... 1, 2, free?!", "::endgroup::" });
-        }
-
-        static StringWriter InterceptOut()
-        {
-            StringWriter interceptor = new();
-            Console.SetOut(interceptor);
-
-            return interceptor;
-        }
-
-        static void AssertCommand(StringWriter writer, string[] expectedCommands)
-        {
-            var actualCommands =
-                writer.ToString()
-                    .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
-            Assert.Equal(expectedCommands.Length, actualCommands.Length);
-
-            for (var i = 0; i < expectedCommands.Length; ++i)
-            {
-                Assert.Equal(expectedCommands[i], actualCommands[i]);
-            }
-        }
-
-        public void Dispose() => Console.SetOut(s_consoleOut);
+        AssertCommand(
+            interceptor,
+            expectedCommands);
     }
+
+    [Fact]
+    public void WriteWarningMessageTest()
+    {
+        var interceptor = InterceptOut();
+        IJobService sut = new JobService();
+        sut.Warning("Um, not sure....but something feels off!");
+
+        AssertCommand(
+            interceptor,
+            new[] { "::warning::Um, not sure....but something feels off!" });
+    }
+
+    [Fact]
+    public void WriteDebugMessageTest()
+    {
+        var interceptor = InterceptOut();
+        IJobService sut = new JobService();
+        sut.Debug("Does this really work?");
+
+        AssertCommand(
+            interceptor,
+            new[] { "::debug::Does this really work?" });
+    }
+
+    [Fact]
+    public void GroupMessagesTest()
+    {
+        var interceptor = InterceptOut();
+        IJobService sut = new JobService();
+        sut.StartGroup("example");
+        sut.Info("Testing... 1, 2, free?!");
+        sut.EndGroup();
+
+        AssertCommand(
+            interceptor,
+            new[] { "::group::example", "Testing... 1, 2, free?!", "::endgroup::" });
+    }
+
+    static StringWriter InterceptOut()
+    {
+        StringWriter interceptor = new();
+        Console.SetOut(interceptor);
+
+        return interceptor;
+    }
+
+    static void AssertCommand(StringWriter writer, string[] expectedCommands)
+    {
+        var actualCommands =
+            writer.ToString()
+                .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(expectedCommands.Length, actualCommands.Length);
+
+        for (var i = 0; i < expectedCommands.Length; ++i)
+        {
+            Assert.Equal(expectedCommands[i], actualCommands[i]);
+        }
+    }
+
+    public void Dispose() => Console.SetOut(s_consoleOut);
 }

--- a/test/DotNet.GitHubActionsTests/WorkflowCommandTests.cs
+++ b/test/DotNet.GitHubActionsTests/WorkflowCommandTests.cs
@@ -1,15 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using DotNet.GitHubActions;
 using Xunit;
 
-namespace DotNet.GitHubActionsTests
+namespace DotNet.GitHubActionsTests;
+
+public class WorkflowCommandTests
 {
-    public class WorkflowCommandTests
-    {
-        public static IEnumerable<object[]> WorkflowCommandToStringInput = new[]
+    public static IEnumerable<object[]> WorkflowCommandToStringInput = new[]
 {
             new object[]
             {
@@ -33,15 +32,14 @@ namespace DotNet.GitHubActionsTests
             }
         };
 
-        [
-            Theory,
-            MemberData(nameof(WorkflowCommandToStringInput))
-        ]
-        public void WorkflowCommandToStringTest<T>(
-            string name, T message, Dictionary<string, string> properties, string expected)
-        {
-            WorkflowCommand<T> command = new(name, message, properties);
-            Assert.Equal(expected, command.ToString());
-        }
+    [
+        Theory,
+        MemberData(nameof(WorkflowCommandToStringInput))
+    ]
+    public void WorkflowCommandToStringTest<T>(
+        string name, T message, Dictionary<string, string> properties, string expected)
+    {
+        WorkflowCommand<T> command = new(name, message, properties);
+        Assert.Equal(expected, command.ToString());
     }
 }

--- a/test/DotNet.GitHubTests/DotNet.GitHubTests.csproj
+++ b/test/DotNet.GitHubTests/DotNet.GitHubTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/DotNet.GitHubTests/DotNet.GitHubTests.csproj
+++ b/test/DotNet.GitHubTests/DotNet.GitHubTests.csproj
@@ -1,21 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.14" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/DotNet.GitHubTests/GitHubLabelServiceTests.cs
+++ b/test/DotNet.GitHubTests/GitHubLabelServiceTests.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using DotNet.GitHub;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -13,93 +9,92 @@ using NSubstitute;
 using Octokit;
 using Xunit;
 
-namespace DotNet.GitHubTests
+namespace DotNet.GitHubTests;
+
+public class GitHubLabelServiceTests
 {
-    public class GitHubLabelServiceTests
+    readonly ILogger<GitHubLabelService> _logger = new LoggerFactory().CreateLogger<GitHubLabelService>();
+    readonly MemoryCache _cache = new(Options.Create(new MemoryCacheOptions()));
+
+    [Fact]
+    public async Task GetOrCreateLabelAsyncCorrectlyReadsLabel()
     {
-        readonly ILogger<GitHubLabelService> _logger = new LoggerFactory().CreateLogger<GitHubLabelService>();
-        readonly MemoryCache _cache = new(Options.Create(new MemoryCacheOptions()));
+        var factory = SubstituteWith(
+            new[] { new TestLabel("dotnet-target-version") },
+            new("Label")).Factory;
 
-        [Fact]
-        public async Task GetOrCreateLabelAsyncCorrectlyReadsLabel()
-        {
-            var factory = SubstituteWith(
-                new[] { new TestLabel("dotnet-target-version") },
-                new("Label")).Factory;
+        var sut = new GitHubLabelService(factory, _logger, _cache);
+        var label = await sut.GetOrCreateLabelAsync("unit", "test", "fake");
 
-            var sut = new GitHubLabelService(factory, _logger, _cache);
-            var label = await sut.GetOrCreateLabelAsync("unit", "test", "fake");
-
-            Assert.Equal("dotnet-target-version", label.Name);
-        }
-
-        [Fact]
-        public async Task GetOrCreateLabelAsyncCreatesLabel()
-        {
-            var (labelsClient, _, factory) = SubstituteWith(
-                Array.Empty<TestLabel>(), new TestLabel("dotnet-target-version"));
-
-            var sut = new GitHubLabelService(factory, _logger, _cache);
-            var label = await sut.GetOrCreateLabelAsync("unit", "test", "fake");
-
-            await labelsClient.Received(1).Create(
-                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<NewLabel>());
-
-            Assert.Equal("dotnet-target-version", label.Name);
-        }
-
-        [Fact]
-        public async Task GetOrCreateLabelAsyncOnlyCreatesLabelOnce()
-        {
-            var (labelsClient, _, factory) = SubstituteWith(
-                Array.Empty<TestLabel>(), new TestLabel("dotnet-target-version"));
-
-            var floodCount = 10_000;
-            var sut = new GitHubLabelService(factory, _logger, _cache);
-            var labels = await Task.WhenAll(
-                Enumerable.Range(0, floodCount)
-                    .Select(i => sut.GetOrCreateLabelAsync("unit", "test", "fake")
-                    .AsTask()));
-
-            factory.Received(floodCount).Create(Arg.Any<string>());
-            await labelsClient.Received(1).Create(
-                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<NewLabel>());
-            await labelsClient.Received(2).GetAllForRepository(
-                Arg.Any<string>(), Arg.Any<string>());
-
-            Assert.Equal("dotnet-target-version", labels[0].Name);
-        }
-
-        /// <summary>
-        /// Creates several substitutions based on the given inputs
-        /// </summary>
-        /// <param name="allLabels">The labels returns from the <see cref="IIssuesLabelsClient.GetAllForRepository(string, string)"/> call.</param>
-        /// <param name="createdLabel">The label returned from the <see cref="IIssuesLabelsClient.Create(string, string, NewLabel)"/> call</param>
-        /// <returns></returns>
-        private static (IIssuesLabelsClient LabelsClient, IIssuesClient IssuesClient, IResilientGitHubClientFactory Factory)
-            SubstituteWith(
-                IReadOnlyList<TestLabel> allLabels,
-                TestLabel createdLabel)
-        {
-            var labelsClient = Substitute.For<IIssuesLabelsClient>();
-            labelsClient.GetAllForRepository(null, null).ReturnsForAnyArgs(allLabels);
-            labelsClient.Create(null, null, null).ReturnsForAnyArgs(createdLabel);
-
-            var issuesClient = Substitute.For<IIssuesClient>();
-            issuesClient.Labels.ReturnsForAnyArgs(labelsClient);
-
-            var client = Substitute.For<IGitHubClient>();
-            client.Issue.Returns(issuesClient);
-
-            var factory = Substitute.For<IResilientGitHubClientFactory>();
-            factory.Create(null).ReturnsForAnyArgs(client);
-
-            return (labelsClient, issuesClient, factory);
-        }
+        Assert.Equal("dotnet-target-version", label.Name);
     }
 
-    public class TestLabel : Label
+    [Fact]
+    public async Task GetOrCreateLabelAsyncCreatesLabel()
     {
-        public TestLabel(string name) => Name = name;
+        var (labelsClient, _, factory) = SubstituteWith(
+            Array.Empty<TestLabel>(), new TestLabel("dotnet-target-version"));
+
+        var sut = new GitHubLabelService(factory, _logger, _cache);
+        var label = await sut.GetOrCreateLabelAsync("unit", "test", "fake");
+
+        await labelsClient.Received(1).Create(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<NewLabel>());
+
+        Assert.Equal("dotnet-target-version", label.Name);
     }
+
+    [Fact]
+    public async Task GetOrCreateLabelAsyncOnlyCreatesLabelOnce()
+    {
+        var (labelsClient, _, factory) = SubstituteWith(
+            Array.Empty<TestLabel>(), new TestLabel("dotnet-target-version"));
+
+        var floodCount = 10_000;
+        var sut = new GitHubLabelService(factory, _logger, _cache);
+        var labels = await Task.WhenAll(
+            Enumerable.Range(0, floodCount)
+                .Select(i => sut.GetOrCreateLabelAsync("unit", "test", "fake")
+                .AsTask()));
+
+        factory.Received(floodCount).Create(Arg.Any<string>());
+        await labelsClient.Received(1).Create(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<NewLabel>());
+        await labelsClient.Received(2).GetAllForRepository(
+            Arg.Any<string>(), Arg.Any<string>());
+
+        Assert.Equal("dotnet-target-version", labels[0].Name);
+    }
+
+    /// <summary>
+    /// Creates several substitutions based on the given inputs
+    /// </summary>
+    /// <param name="allLabels">The labels returns from the <see cref="IIssuesLabelsClient.GetAllForRepository(string, string)"/> call.</param>
+    /// <param name="createdLabel">The label returned from the <see cref="IIssuesLabelsClient.Create(string, string, NewLabel)"/> call</param>
+    /// <returns></returns>
+    private static (IIssuesLabelsClient LabelsClient, IIssuesClient IssuesClient, IResilientGitHubClientFactory Factory)
+        SubstituteWith(
+            IReadOnlyList<TestLabel> allLabels,
+            TestLabel createdLabel)
+    {
+        var labelsClient = Substitute.For<IIssuesLabelsClient>();
+        labelsClient.GetAllForRepository(null, null).ReturnsForAnyArgs(allLabels);
+        labelsClient.Create(null, null, null).ReturnsForAnyArgs(createdLabel);
+
+        var issuesClient = Substitute.For<IIssuesClient>();
+        issuesClient.Labels.ReturnsForAnyArgs(labelsClient);
+
+        var client = Substitute.For<IGitHubClient>();
+        client.Issue.Returns(issuesClient);
+
+        var factory = Substitute.For<IResilientGitHubClientFactory>();
+        factory.Create(null).ReturnsForAnyArgs(client);
+
+        return (labelsClient, issuesClient, factory);
+    }
+}
+
+public class TestLabel : Label
+{
+    public TestLabel(string name) => Name = name;
 }

--- a/test/DotNet.GitHubTests/GraphQLRequestTests.cs
+++ b/test/DotNet.GitHubTests/GraphQLRequestTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -10,42 +9,42 @@ using DotNet.GitHub;
 using Octokit;
 using Xunit;
 
-namespace DotNet.GitHubTests
-{
-    public class GraphQLRequestTests
-    {
-        readonly static JsonSerializerOptions _options = new()
-        {
-            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
-            PropertyNameCaseInsensitive = true
-        };
+namespace DotNet.GitHubTests;
 
-        [Fact]
-        public void RequestObjectCorrectlySerializesToJsonTest()
+public class GraphQLRequestTests
+{
+    readonly static JsonSerializerOptions _options = new()
+    {
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        PropertyNameCaseInsensitive = true
+    };
+
+    [Fact]
+    public void RequestObjectCorrectlySerializesToJsonTest()
+    {
+        GraphQLRequest request = new()
         {
-            GraphQLRequest request = new()
-            {
-                Query = @"query {
+            Query = @"query {
   viewer {
     login
   }
 }"
-            };
+        };
 
-            var expectedJson = @"{""query"":""query {
+        var expectedJson = @"{""query"":""query {
   viewer {
     login
   }
 }"",""variables"":{}}";
-            var actualJson = Regex.Unescape(request.ToString());
+        var actualJson = Regex.Unescape(request.ToString());
 
-            Assert.Equal(expectedJson, actualJson);
-        }
+        Assert.Equal(expectedJson, actualJson);
+    }
 
-        [Fact]
-        public void ResponseJsonCorrectlyDeserializesTest()
-        {
-            const string responseJson = @"{
+    [Fact]
+    public void ResponseJsonCorrectlyDeserializesTest()
+    {
+        const string responseJson = @"{
     ""data"": {
         ""search"": {
             ""nodes"": [
@@ -62,24 +61,23 @@ namespace DotNet.GitHubTests
         }
     }
 }";
-            ExistingIssue expectedIssue = new()
-            {
-                Title = "Update generation.csproj from .NET Core 2.2 to LTS(or current) version",
-                Number = 4141,
-                Url = "https://github.com/dotnet/samples/issues/4141",
-                State = ItemState.Open,
-                CreatedAt = new DateTime(2021, 1, 25, 20, 49, 23, DateTimeKind.Utc),
-                UpdatedAt = new DateTime(2021, 1, 25, 20, 49, 23, DateTimeKind.Utc),
-                ClosedAt = null
-            };
+        ExistingIssue expectedIssue = new()
+        {
+            Title = "Update generation.csproj from .NET Core 2.2 to LTS(or current) version",
+            Number = 4141,
+            Url = "https://github.com/dotnet/samples/issues/4141",
+            State = ItemState.Open,
+            CreatedAt = new DateTime(2021, 1, 25, 20, 49, 23, DateTimeKind.Utc),
+            UpdatedAt = new DateTime(2021, 1, 25, 20, 49, 23, DateTimeKind.Utc),
+            ClosedAt = null
+        };
 
-            var actualIssue =
-                responseJson.FromJson<GraphQLResult<ExistingIssue>>(_options)
-                    .Data
-                    .Search
-                    .Nodes[0];
+        var actualIssue =
+            responseJson.FromJson<GraphQLResult<ExistingIssue>>(_options)
+                .Data
+                .Search
+                .Nodes[0];
 
-            Assert.Equal(expectedIssue, actualIssue);
-        }
+        Assert.Equal(expectedIssue, actualIssue);
     }
 }

--- a/test/DotNet.IOTests/Constants.cs
+++ b/test/DotNet.IOTests/Constants.cs
@@ -1,11 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DotNet.IOTests
+namespace DotNet.IOTests;
+
+class Constants
 {
-    class Constants
-    {
-        internal const string TestSolutionXml = @"
+    internal const string TestSolutionXml = @"
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30803.129
@@ -42,7 +42,7 @@ Global
 EndGlobal
 ";
 
-        internal const string TestProjectXml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+    internal const string TestProjectXml = @"<Project Sdk=""Microsoft.NET.Sdk"">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -60,7 +60,7 @@ EndGlobal
 
 </Project>";
 
-        internal const string TestProjectJson = @"{
+    internal const string TestProjectJson = @"{
   ""version"": ""1.0.0-*"",
   ""buildOptions"": {
     ""emitEntryPoint"": true
@@ -104,7 +104,7 @@ EndGlobal
   }
 }";
 
-        internal const string TestProjectJsonMultipleTfms = @"{
+    internal const string TestProjectJsonMultipleTfms = @"{
   ""version"": ""1.0.0-*"",
   ""tooling"": {
     ""defaultNamespace"": ""vscode_aspnet5""
@@ -157,5 +157,4 @@ EndGlobal
     ]
   }
 }";
-    }
 }

--- a/test/DotNet.IOTests/DotNet.IOTests.csproj
+++ b/test/DotNet.IOTests/DotNet.IOTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/DotNet.IOTests/DotNet.IOTests.csproj
+++ b/test/DotNet.IOTests/DotNet.IOTests.csproj
@@ -1,16 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/DotNet.IOTests/Project/ProjectFileReaderTests.cs
+++ b/test/DotNet.IOTests/Project/ProjectFileReaderTests.cs
@@ -1,66 +1,63 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
-using System.Threading.Tasks;
 using DotNet.IO;
 using Xunit;
 
-namespace DotNet.IOTests
+namespace DotNet.IOTests;
+
+public class ProjectFileReaderTests
 {
-    public class ProjectFileReaderTests
+    [Fact]
+    public async Task ReadProjectAndParseXmlCorrectly()
     {
-        [Fact]
-        public async Task ReadProjectAndParseXmlCorrectly()
+        var projectPath = "test.csproj";
+
+        try
         {
-            var projectPath = "test.csproj";
+            await File.WriteAllTextAsync(projectPath, Constants.TestProjectXml);
 
-            try
-            {
-                await File.WriteAllTextAsync(projectPath, Constants.TestProjectXml);
+            IProjectFileReader sut = new ProjectFileReader();
 
-                IProjectFileReader sut = new ProjectFileReader();
-
-                var project = await sut.ReadProjectAsync(projectPath);
-                Assert.Equal(4, project.TfmLineNumber);
-                Assert.Single(project.Tfms);
-                Assert.Equal("net5.0", project.Tfms[0]);
-                Assert.Equal("Microsoft.NET.Sdk", project.Sdk);
-            }
-            finally
-            {
-                File.Delete(projectPath);
-            }
+            var project = await sut.ReadProjectAsync(projectPath);
+            Assert.Equal(4, project.TfmLineNumber);
+            Assert.Single(project.Tfms);
+            Assert.Equal("net5.0", project.Tfms[0]);
+            Assert.Equal("Microsoft.NET.Sdk", project.Sdk);
         }
-
-        [
-            Theory,
-            InlineData("test-1.json", Constants.TestProjectJson, 18, "netcoreapp1.0"),
-            InlineData("test-2.json", Constants.TestProjectJsonMultipleTfms, 27, "dnx46", "dnxcore50")
-        ]
-        public async Task ReadProjectAndParseJsonCorrectly(
-            string projectPath, string content, int expectedLineNumber, params string[] expectedTfms)
+        finally
         {
+            File.Delete(projectPath);
+        }
+    }
 
-            try
+    [
+        Theory,
+        InlineData("test-1.json", Constants.TestProjectJson, 18, "netcoreapp1.0"),
+        InlineData("test-2.json", Constants.TestProjectJsonMultipleTfms, 27, "dnx46", "dnxcore50")
+    ]
+    public async Task ReadProjectAndParseJsonCorrectly(
+        string projectPath, string content, int expectedLineNumber, params string[] expectedTfms)
+    {
+
+        try
+        {
+            await File.WriteAllTextAsync(projectPath, content);
+
+            IProjectFileReader sut = new ProjectFileReader();
+
+            var project = await sut.ReadProjectAsync(projectPath);
+            Assert.Equal(expectedLineNumber, project.TfmLineNumber);
+            Assert.Equal(expectedTfms.Length, project.Tfms.Length);
+            for (var i = 0; i < expectedTfms.Length; ++i)
             {
-                await File.WriteAllTextAsync(projectPath, content);
-
-                IProjectFileReader sut = new ProjectFileReader();
-
-                var project = await sut.ReadProjectAsync(projectPath);
-                Assert.Equal(expectedLineNumber, project.TfmLineNumber);
-                Assert.Equal(expectedTfms.Length, project.Tfms.Length);
-                for (var i = 0; i < expectedTfms.Length; ++i)
-                {
-                    Assert.Equal(expectedTfms[i], project.Tfms[i]);
-                }
-                Assert.Null(project.Sdk);
+                Assert.Equal(expectedTfms[i], project.Tfms[i]);
             }
-            finally
-            {
-                File.Delete(projectPath);
-            }
+            Assert.Null(project.Sdk);
+        }
+        finally
+        {
+            File.Delete(projectPath);
         }
     }
 }

--- a/test/DotNet.IOTests/Solution/SolutionFileReaderTests.cs
+++ b/test/DotNet.IOTests/Solution/SolutionFileReaderTests.cs
@@ -1,59 +1,54 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using DotNet.IO;
 using Xunit;
 
-namespace DotNet.IOTests
+namespace DotNet.IOTests;
+
+public class SolutionFileReaderTests
 {
-    public class SolutionFileReaderTests
+    [Fact]
+    public async Task ReadSolutionAsyncTest()
     {
-        [Fact]
-        public async Task ReadSolutionAsyncTest()
+        var solutionPath = "test.sln";
+        Dictionary<string, string> files = new()
         {
-            var solutionPath = "test.sln";
-            Dictionary<string, string> files = new()
+            ["sln-test.csproj"] = Constants.TestProjectXml,
+            ["sln-test.json"] = Constants.TestProjectJson,
+            [solutionPath] = Constants.TestSolutionXml
+        };
+
+        try
+        {
+            foreach (var (path, content) in files)
             {
-                ["sln-test.csproj"] = Constants.TestProjectXml,
-                ["sln-test.json"] = Constants.TestProjectJson,
-                [solutionPath] = Constants.TestSolutionXml
-            };
-
-            try
-            {
-                foreach (var (path, content) in files)
-                {
-                    await File.WriteAllTextAsync(path, content);
-                }
-
-                ISolutionFileReader sut = new SolutionFileReader(new ProjectFileReader());
-
-                var solution = await sut.ReadSolutionAsync(solutionPath);
-                Assert.NotNull(solution);
-                Assert.Equal(Path.GetFullPath(solutionPath), solution.FullPath);
-                Assert.NotEmpty(solution.Projects);
-
-                var project = solution.Projects.FirstOrDefault(p => !p.IsSdkStyle);
-                Assert.Equal(18, project.TfmLineNumber);
-                Assert.Single(project.Tfms);
-                Assert.Equal("netcoreapp1.0", project.Tfms[0]);
-
-                project = solution.Projects.FirstOrDefault(p => p.IsSdkStyle);
-                Assert.Equal(4, project.TfmLineNumber);
-                Assert.Single(project.Tfms);
-                Assert.Equal("net5.0", project.Tfms[0]);
-                Assert.Equal("Microsoft.NET.Sdk", project.Sdk);
+                await File.WriteAllTextAsync(path, content);
             }
-            finally
+
+            ISolutionFileReader sut = new SolutionFileReader(new ProjectFileReader());
+
+            var solution = await sut.ReadSolutionAsync(solutionPath);
+            Assert.NotNull(solution);
+            Assert.Equal(Path.GetFullPath(solutionPath), solution.FullPath);
+            Assert.NotEmpty(solution.Projects);
+
+            var project = solution.Projects.FirstOrDefault(p => !p.IsSdkStyle);
+            Assert.Equal(18, project.TfmLineNumber);
+            Assert.Single(project.Tfms);
+            Assert.Equal("netcoreapp1.0", project.Tfms[0]);
+
+            project = solution.Projects.FirstOrDefault(p => p.IsSdkStyle);
+            Assert.Equal(4, project.TfmLineNumber);
+            Assert.Single(project.Tfms);
+            Assert.Equal("net5.0", project.Tfms[0]);
+            Assert.Equal("Microsoft.NET.Sdk", project.Sdk);
+        }
+        finally
+        {
+            foreach (var path in files.Keys)
             {
-                foreach (var path in files.Keys)
-                {
-                    File.Delete(path);
-                }
+                File.Delete(path);
             }
         }
     }

--- a/test/DotNet.ModelsTests/DotNet.ModelsTests.csproj
+++ b/test/DotNet.ModelsTests/DotNet.ModelsTests.csproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/DotNet.ModelsTests/DotNet.ModelsTests.csproj
+++ b/test/DotNet.ModelsTests/DotNet.ModelsTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/DotNet.ModelsTests/FrameworkReleaseTests.cs
+++ b/test/DotNet.ModelsTests/FrameworkReleaseTests.cs
@@ -4,29 +4,28 @@
 using DotNet.Models;
 using Xunit;
 
-namespace DotNet.ModelsTests
+namespace DotNet.ModelsTests;
+
+public class FrameworkReleaseTests
 {
-    public class FrameworkReleaseTests
-    {
-        [
-            Theory,
-            InlineData("3.5.0-sp1", "net35"),
-            InlineData("4.0", "net40"),
-            InlineData("4.5", "net45"),
-            InlineData("v4.5.1", "net451"),
-            InlineData("4.5.1", "net451"),
-            InlineData("4.5.2", "net452"),
-            InlineData("net46", "net46"),
-            InlineData("4.6", "net46"),
-            InlineData("net46-preview-3", "net46"),
-            InlineData("v4.7.1", "net471"),
-            InlineData("4.8", "net48")
-        ]
-        public void FrameworkReleaseCorrectlyRepresentsTfm(
-            string version, string expectedTfm) =>
-            Assert.Equal(
-                expectedTfm,
-                new FrameworkRelease(version, null, null, null, null, null, null)
-                    .TargetFrameworkMoniker);
-    }
+    [
+        Theory,
+        InlineData("3.5.0-sp1", "net35"),
+        InlineData("4.0", "net40"),
+        InlineData("4.5", "net45"),
+        InlineData("v4.5.1", "net451"),
+        InlineData("4.5.1", "net451"),
+        InlineData("4.5.2", "net452"),
+        InlineData("net46", "net46"),
+        InlineData("4.6", "net46"),
+        InlineData("net46-preview-3", "net46"),
+        InlineData("v4.7.1", "net471"),
+        InlineData("4.8", "net48")
+    ]
+    public void FrameworkReleaseCorrectlyRepresentsTfm(
+        string version, string expectedTfm) =>
+        Assert.Equal(
+            expectedTfm,
+            new FrameworkRelease(version, null, null, null, null, null, null)
+                .TargetFrameworkMoniker);
 }

--- a/test/DotNet.ModelsTests/ProjectTests.cs
+++ b/test/DotNet.ModelsTests/ProjectTests.cs
@@ -1,17 +1,15 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using DotNet.Models;
 using Xunit;
 
-namespace DotNet.ModelsTests
+namespace DotNet.ModelsTests;
+
+public class ProjectTests
 {
-    public class ProjectTests
+    public static IEnumerable<object[]> NewProjectInput = new[]
     {
-        public static IEnumerable<object[]> NewProjectInput = new[]
-        {
             new object[] { "netcoreapp1.1", "project-path.csproj", ".csproj", new[] { "netcoreapp1.1" } },
             new object[] { "net5.0;netstandard2.0", "some/path.vbproj", ".vbproj", new[] { "net5.0", "netstandard2.0" } },
             new object[] { ";;net46", "old/bits/sample.fsproj", ".fsproj", new[] { "net46" } },
@@ -20,21 +18,20 @@ namespace DotNet.ModelsTests
             new object[] { "netcoreapp3.1", null, null, new[] { "netcoreapp3.1" } }
         };
 
-        [
-            Theory,
-            MemberData(nameof(NewProjectInput))
-        ]
-        public void ProjectCorrectlyHandlesProperties(
-            string actualTfms, string actualPath, string expectedExt, string[] expectedTfms)
+    [
+        Theory,
+        MemberData(nameof(NewProjectInput))
+    ]
+    public void ProjectCorrectlyHandlesProperties(
+        string actualTfms, string actualPath, string expectedExt, string[] expectedTfms)
+    {
+        Project project = new()
         {
-            Project project = new()
-            {
-                FullPath = actualPath,
-                RawTargetFrameworkMonikers = actualTfms
-            };
+            FullPath = actualPath,
+            RawTargetFrameworkMonikers = actualTfms
+        };
 
-            Assert.Equal(expectedExt, project.Extension);
-            Assert.Equal(expectedTfms, project.Tfms);
-        }
+        Assert.Equal(expectedExt, project.Extension);
+        Assert.Equal(expectedTfms, project.Tfms);
     }
 }

--- a/test/DotNet.ModelsTests/ReleaseFactoryTests.cs
+++ b/test/DotNet.ModelsTests/ReleaseFactoryTests.cs
@@ -5,31 +5,30 @@ using DotNet.Models;
 using Microsoft.Deployment.DotNet.Releases;
 using Xunit;
 
-namespace DotNet.ModelsTests
+namespace DotNet.ModelsTests;
+
+public class ReleaseFactoryTests
 {
-    public class ReleaseFactoryTests
+    [Fact]
+    public void CreateTest()
     {
-        [Fact]
-        public void CreateTest()
-        {
-            var example = new Example();
-            var release = ReleaseFactory.Create(
-                example,
-                _ => "Does this thing work",
-                "test",
-                SupportPhase.LTS,
-                null,
-                "some-path.md");
+        var example = new Example();
+        var release = ReleaseFactory.Create(
+            example,
+            _ => "Does this thing work",
+            "test",
+            SupportPhase.LTS,
+            null,
+            "some-path.md");
 
-            Assert.Equal(SupportPhase.LTS, release.SupportPhase);
-            Assert.Equal("Does this thing work", release.ToBrandString());
-            Assert.Equal("test", release.TargetFrameworkMoniker);
-            Assert.Null(release.EndOfLifeDate);
-            Assert.Equal("some-path.md", release.ReleaseNotesUrl);
-        }
+        Assert.Equal(SupportPhase.LTS, release.SupportPhase);
+        Assert.Equal("Does this thing work", release.ToBrandString());
+        Assert.Equal("test", release.TargetFrameworkMoniker);
+        Assert.Null(release.EndOfLifeDate);
+        Assert.Equal("some-path.md", release.ReleaseNotesUrl);
+    }
 
-        class Example
-        {
-        }
+    class Example
+    {
     }
 }

--- a/test/DotNet.ReleasesTests/DotNet.ReleasesTests.csproj
+++ b/test/DotNet.ReleasesTests/DotNet.ReleasesTests.csproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/DotNet.ReleasesTests/DotNet.ReleasesTests.csproj
+++ b/test/DotNet.ReleasesTests/DotNet.ReleasesTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/DotNet.ReleasesTests/Framework/FrameworkReleaseServiceTests.cs
+++ b/test/DotNet.ReleasesTests/Framework/FrameworkReleaseServiceTests.cs
@@ -1,36 +1,34 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading.Tasks;
 using DotNet.Releases;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Xunit;
 
-namespace DotNet.ReleasesTests
+namespace DotNet.ReleasesTests;
+
+public class FrameworkReleaseServiceTests
 {
-    public class FrameworkReleaseServiceTests
+    readonly IFrameworkReleaseIndexService _indexService = new FrameworkReleaseIndexService();
+    readonly MemoryCache _cache = new(Options.Create(new MemoryCacheOptions()));
+
+    [
+        Theory,
+        InlineData("4.5", "4.8"),
+        InlineData("4.5.2", "4.8"),
+        InlineData("4.6.1", "4.8"),
+        InlineData("4.7", "4.8"),
+        InlineData("4.7.2", "4.8"),
+        InlineData("4.6", "4.8")
+    ]
+    public async Task GetNextLtsVersionAsyncTest(
+        string releaseVersion, string expectedVersion)
     {
-        readonly IFrameworkReleaseIndexService _indexService = new FrameworkReleaseIndexService();
-        readonly MemoryCache _cache = new(Options.Create(new MemoryCacheOptions()));
+        IFrameworkReleaseService service =
+            new FrameworkReleaseService(_indexService, _cache);
 
-        [
-            Theory,
-            InlineData("4.5", "4.8"),
-            InlineData("4.5.2", "4.8"),
-            InlineData("4.6.1", "4.8"),
-            InlineData("4.7", "4.8"),
-            InlineData("4.7.2", "4.8"),
-            InlineData("4.6", "4.8")
-        ]
-        public async Task GetNextLtsVersionAsyncTest(
-            string releaseVersion, string expectedVersion)
-        {
-            IFrameworkReleaseService service =
-                new FrameworkReleaseService(_indexService, _cache);
-
-            var result = await service.GetNextLtsVersionAsync(releaseVersion);
-            Assert.Equal(expectedVersion, result.Version);
-        }
+        var result = await service.GetNextLtsVersionAsync(releaseVersion);
+        Assert.Equal(expectedVersion, result.Version);
     }
 }

--- a/test/DotNet.ReleasesTests/LabeledVersionTests.cs
+++ b/test/DotNet.ReleasesTests/LabeledVersionTests.cs
@@ -1,17 +1,15 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using DotNet.Releases;
 using Xunit;
 
-namespace DotNet.ReleasesTests
+namespace DotNet.ReleasesTests;
+
+public class LabeledVersionTests
 {
-    public class LabeledVersionTests
+    public static IEnumerable<object[]> AsLabeledVersionInput = new[]
     {
-        public static IEnumerable<object[]> AsLabeledVersionInput = new[]
-        {
             new object[] { "5.0", new LabeledVersion(new Version(5, 0)) },
             new object[] { "5.0.2", new LabeledVersion(new Version(5, 0, 2)) },
             new object[] { "3.1.405", new LabeledVersion(new Version(3, 1, 405)) },
@@ -22,11 +20,10 @@ namespace DotNet.ReleasesTests
             new object[] { "pickles", new LabeledVersion(null) }
         };
 
-        [
-            Theory,
-            MemberData(nameof(AsLabeledVersionInput))
-        ]
-        public void AsLabeledVersionTest(string version, LabeledVersion expectedVersion) =>
-            Assert.Equal(expectedVersion, version);
-    }
+    [
+        Theory,
+        MemberData(nameof(AsLabeledVersionInput))
+    ]
+    public void AsLabeledVersionTest(string version, LabeledVersion expectedVersion) =>
+        Assert.Equal(expectedVersion, version);
 }

--- a/test/DotNet.VersionSweeperTests/DotNet.VersionSweeperTests.csproj
+++ b/test/DotNet.VersionSweeperTests/DotNet.VersionSweeperTests.csproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/DotNet.VersionSweeperTests/DotNet.VersionSweeperTests.csproj
+++ b/test/DotNet.VersionSweeperTests/DotNet.VersionSweeperTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/DotNet.VersionSweeperTests/OptionsTests.cs
+++ b/test/DotNet.VersionSweeperTests/OptionsTests.cs
@@ -1,16 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using DotNet.VersionSweeper;
 using Xunit;
 
-namespace DotNet.VersionSweeperTests
+namespace DotNet.VersionSweeperTests;
+
+public class OptionsTests
 {
-    public class OptionsTests
-    {
-        public static IEnumerable<object[]> NewOptionsSearchPatternInput = new[]
+    public static IEnumerable<object[]> NewOptionsSearchPatternInput = new[]
 {
             new object[] { "*.csproj|project.json", new[] { "**/*.csproj", "**/project.json" } },
             new object[] { "*.fsproj;*.vbproj", new[] { "**/*.fsproj", "**/*.vbproj" } },
@@ -19,23 +17,22 @@ namespace DotNet.VersionSweeperTests
             new object[] { null, Array.Empty<string>() }
         };
 
-        [
-            Theory,
-            MemberData(nameof(NewOptionsSearchPatternInput))
-        ]
-        public void OptionsSearchPatternIsCorrectlyParsed(
-            string inputPattern, IEnumerable<string> expectedPatterns)
+    [
+        Theory,
+        MemberData(nameof(NewOptionsSearchPatternInput))
+    ]
+    public void OptionsSearchPatternIsCorrectlyParsed(
+        string inputPattern, IEnumerable<string> expectedPatterns)
+    {
+        Options options = new()
         {
-            Options options = new()
-            {
-                SearchPattern = inputPattern
-            };
+            SearchPattern = inputPattern
+        };
 
-            Assert.Equal(
-                expectedPatterns,
-                options.SearchPattern
-                    .SplitOnExpectedDelimiters()
-                    .AsRecursivePatterns());
-        }
+        Assert.Equal(
+            expectedPatterns,
+            options.SearchPattern
+                .SplitOnExpectedDelimiters()
+                .AsRecursivePatterns());
     }
 }

--- a/test/DotNet.VersionSweeperTests/StringExtensionsTests.cs
+++ b/test/DotNet.VersionSweeperTests/StringExtensionsTests.cs
@@ -1,17 +1,15 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using DotNet.VersionSweeper;
 using Xunit;
 
-namespace DotNet.VersionSweeperTests
+namespace DotNet.VersionSweeperTests;
+
+public class StringExtensionsTests
 {
-    public class StringExtensionsTests
+    public static IEnumerable<object[]> AsMaskedExtensionsInput = new[]
     {
-        public static IEnumerable<object[]> AsMaskedExtensionsInput = new[]
-        {
             new object[] { "*.csproj", new string[] { "*.csproj" } },
             new object[] { "*.csproj|*.fsproj", new string[] { "*.csproj", "*.fsproj" } },
             new object[] { "*.csproj,*.fsproj", new string[] { "*.csproj", "*.fsproj" } },
@@ -20,11 +18,10 @@ namespace DotNet.VersionSweeperTests
             new object[] { "", Array.Empty<string>() }
         };
 
-        [
-            Theory,
-            MemberData(nameof(AsMaskedExtensionsInput))
-        ]
-        public void AsMaskedExtensionsTest(string pattern, string[] expected) =>
-            Assert.Equal(expected, pattern.SplitOnExpectedDelimiters());
-    }
+    [
+        Theory,
+        MemberData(nameof(AsMaskedExtensionsInput))
+    ]
+    public void AsMaskedExtensionsTest(string pattern, string[] expected) =>
+        Assert.Equal(expected, pattern.SplitOnExpectedDelimiters());
 }


### PR DESCRIPTION
Upgrade the version sweeper to .NET 6 and C# 10:

- Upgrade all `net5.0` TFMs to `net6.0`.
- Upgrade GitHub Actions to use .NET 6.
- Upgrade _Dockerfile_ to rely on .NET 6.
- `<ImplicitUsings>enable</ImplicitUsings>`.
- Use file-scoped namespaces everywhere, and promote to `suggestion`.
- Use _GlobalUsings.cs_ pattern where applicable.
- Delete `DistinctBy` custom extension method, as it was added in .NET 6.